### PR TITLE
KeyboardView의 UI 구성을 변경합니다

### DIFF
--- a/CustomKeyboard/CustomKeyboard.xcodeproj/project.pbxproj
+++ b/CustomKeyboard/CustomKeyboard.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		2A2C9AF02A5C61D60021DD33 /* KeyboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A2C9AEF2A5C61D60021DD33 /* KeyboardView.swift */; };
 		2A2C9B502A5E67540021DD33 /* Size.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A2C9B4F2A5E67540021DD33 /* Size.swift */; };
 		2A2C9B532A5EA7D90021DD33 /* KeyButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A2C9B522A5EA7D90021DD33 /* KeyButton.swift */; };
+		2A2C9B552A603CD60021DD33 /* PaddingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A2C9B542A603CD60021DD33 /* PaddingView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -85,6 +86,7 @@
 		2A2C9AEF2A5C61D60021DD33 /* KeyboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardView.swift; sourceTree = "<group>"; };
 		2A2C9B4F2A5E67540021DD33 /* Size.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Size.swift; sourceTree = "<group>"; };
 		2A2C9B522A5EA7D90021DD33 /* KeyButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyButton.swift; sourceTree = "<group>"; };
+		2A2C9B542A603CD60021DD33 /* PaddingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -230,6 +232,7 @@
 			isa = PBXGroup;
 			children = (
 				2A2C9B522A5EA7D90021DD33 /* KeyButton.swift */,
+				2A2C9B542A603CD60021DD33 /* PaddingView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -425,6 +428,7 @@
 			files = (
 				2A2C9B502A5E67540021DD33 /* Size.swift in Sources */,
 				2A2C9AF02A5C61D60021DD33 /* KeyboardView.swift in Sources */,
+				2A2C9B552A603CD60021DD33 /* PaddingView.swift in Sources */,
 				2A2C9AE22A5C61730021DD33 /* KeyboardViewController.swift in Sources */,
 				2A2C9AED2A5C618A0021DD33 /* KeyModel.swift in Sources */,
 				2A2C9B532A5EA7D90021DD33 /* KeyButton.swift in Sources */,

--- a/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
+++ b/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
@@ -12,6 +12,8 @@ class KeyboardViewController: UIInputViewController {
     @IBOutlet var nextKeyboardButton: UIButton!
     private let keyboardView = KeyboardView(frame: .zero)
     
+    var shiftKeyState: ShiftKeyState = .normal
+    
     override func updateViewConstraints() {
         super.updateViewConstraints()
         
@@ -21,6 +23,9 @@ class KeyboardViewController: UIInputViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setUpKeyboardViewLayout()
+        keyboardView.frame = view.bounds
+        keyboardView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        keyboardView.delegate = self
         // Perform custom UI setup here
         self.nextKeyboardButton = UIButton(type: .system)
         
@@ -58,6 +63,21 @@ class KeyboardViewController: UIInputViewController {
         self.nextKeyboardButton.setTitleColor(textColor, for: [])
     }
 
+}
+
+extension KeyboardViewController: KeyboardViewDelegate {
+    
+    func setKeyAction(key: KeyModel) {
+        let proxy = textDocumentProxy as UITextDocumentProxy
+        switch key.uniValue {
+        case 101:
+            keyboardView.backgroundColor = shiftKeyState == .normal ? .white : .systemGray
+        default:
+            proxy.insertText(key.keyword)
+        }
+    }
+    
+    
 }
 
 private extension KeyboardViewController {

--- a/CustomKeyboard/KoreanKeyboard/Literal/Size.swift
+++ b/CustomKeyboard/KoreanKeyboard/Literal/Size.swift
@@ -10,10 +10,16 @@ import UIKit
 enum Size {
     static let width = UIScreen.main.bounds.width
     static let keyRadius: CGFloat = 5
-    static let keyWidth = width / CGFloat(keys.first?.count ?? 10)
+    static let keyWidth = width / CGFloat(keys.first?.count ?? 10) - keyItemSpacing
+    static let keyItemSpacing: CGFloat = 6
+    static let keyRowSpacing: CGFloat = 10
+    
+    static func firstKeyLeadingSpacing(_ keyItemCount: Int) -> CGFloat {
+        return (CGFloat(((keys.first?.count ?? 10) - keyItemCount)) * (Size.keyWidth + Size.keyItemSpacing)) / 2 - keyItemSpacing
+    }
     
     static func keyboardEdgeInsets() -> UIEdgeInsets {
-        return UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0)
+        return UIEdgeInsets(top: 8, left: 3, bottom: 8, right: 3)
     }
     
     static func keyEdgeInsets() -> UIEdgeInsets {

--- a/CustomKeyboard/KoreanKeyboard/Model/KeyModel.swift
+++ b/CustomKeyboard/KoreanKeyboard/Model/KeyModel.swift
@@ -11,10 +11,16 @@ struct KeyModel {
     let keyword: String
     let uniValue: Int
 }
+
+enum ShiftKeyState {
+    case normal
+    case constant
+}
+
 //추후 한글 조합을 위한 유니코드 uniValue 변경 예정
 let keys: [[KeyModel]] = [
         [KeyModel(keyword: "ㅂ", uniValue: 7), KeyModel(keyword: "ㅈ", uniValue: 0), KeyModel(keyword: "ㄷ", uniValue: 0), KeyModel(keyword: "ㄱ", uniValue: 0), KeyModel(keyword: "ㅅ", uniValue: 0), KeyModel(keyword: "ㅛ", uniValue: 0), KeyModel(keyword: "ㅕ", uniValue: 0), KeyModel(keyword: "ㅑ", uniValue: 0), KeyModel(keyword: "ㅐ", uniValue: 0), KeyModel(keyword: "ㅔ", uniValue: 0)],
         [KeyModel(keyword: "ㅁ", uniValue: 0), KeyModel(keyword: "ㄴ", uniValue: 0), KeyModel(keyword: "ㅇ", uniValue: 0), KeyModel(keyword: "ㄹ", uniValue: 0), KeyModel(keyword: "ㅎ", uniValue: 0), KeyModel(keyword: "ㅗ", uniValue: 0), KeyModel(keyword: "ㅓ", uniValue: 0), KeyModel(keyword: "ㅏ", uniValue: 0), KeyModel(keyword: "ㅣ", uniValue: 0)],
         [KeyModel(keyword: "Shift", uniValue: 101), KeyModel(keyword: "ㅋ", uniValue: 0), KeyModel(keyword: "ㅌ", uniValue: 0), KeyModel(keyword: "ㅊ", uniValue: 0), KeyModel(keyword: "ㅍ", uniValue: 0), KeyModel(keyword: "ㅠ", uniValue: 0), KeyModel(keyword: "ㅜ", uniValue: 0), KeyModel(keyword: "ㅡ", uniValue: 0), KeyModel(keyword: "⌫", uniValue: 102)],
-        [KeyModel(keyword: "단축키", uniValue: 103), KeyModel(keyword: "Space", uniValue: 104), KeyModel(keyword: "Enter", uniValue: 105)]
+        [KeyModel(keyword: "🌐", uniValue: 100), KeyModel(keyword: "단축키", uniValue: 103), KeyModel(keyword: "Space", uniValue: 104), KeyModel(keyword: "Enter", uniValue: 105)]
     ]

--- a/CustomKeyboard/KoreanKeyboard/View/Components/KeyButton.swift
+++ b/CustomKeyboard/KoreanKeyboard/View/Components/KeyButton.swift
@@ -7,10 +7,20 @@
 
 import UIKit
 
-final class KeyButtonView: UIView {
+final class KeyButton: UIButton {
+    var keyValue: KeyModel
     
-    var keyButton: UIButton = {
-        let keyButton = UIButton()
+    init(key: KeyModel) {
+        keyValue = key
+        super.init(frame: .zero)
+        self.setTitle(key.keyword, for: .normal)
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    private func configure() {
         if #available(iOS 15.0, *) {
             var buttonConfig = UIButton.Configuration.filled()
             var buttonTitleAttribute = AttributedString()
@@ -18,46 +28,17 @@ final class KeyButtonView: UIView {
             buttonConfig.attributedTitle = buttonTitleAttribute
             buttonConfig.titleAlignment = .center
             buttonConfig.contentInsets = Size.keyEdgeInsetsForConfigure()
+            buttonConfig.baseForegroundColor = .white
             buttonConfig.baseBackgroundColor = .systemGray
-            keyButton.layer.cornerRadius = Size.keyRadius
-            keyButton.configuration = buttonConfig
+            self.layer.cornerRadius = Size.keyRadius
+            self.configuration = buttonConfig
         } else {
-            keyButton.contentEdgeInsets = Size.keyEdgeInsets()
-            keyButton.titleLabel?.font = UIFont.systemFont(ofSize: 17)
-            keyButton.titleLabel?.textAlignment = .center
-            keyButton.backgroundColor = .systemGray
-            keyButton.setTitleColor(.white, for: .normal)
-            keyButton.layer.cornerRadius = Size.keyRadius
+            self.contentEdgeInsets = Size.keyEdgeInsets()
+            self.titleLabel?.font = UIFont.systemFont(ofSize: 17)
+            self.titleLabel?.textAlignment = .center
+            self.backgroundColor = .systemGray
+            self.setTitleColor(.white, for: .normal)
+            self.layer.cornerRadius = Size.keyRadius
         }
-        return keyButton
-    }()
-    var keyValue: KeyModel
-    var tmp = "hi"
-    
-    
-    init(key: KeyModel) {
-        keyValue = key
-        super.init(frame: .zero)
-        
-        keyButton.setTitle(key.keyword, for: .normal)
-        setUpKeyButtonLayout()
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-}
-
-private extension KeyButtonView {
-    func setUpKeyButtonLayout() {
-        addSubview(keyButton)
-        keyButton.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            keyButton.topAnchor.constraint(equalTo: topAnchor, constant: 5),
-            keyButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 3),
-            keyButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -3),
-            keyButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5)
-        ])
     }
 }

--- a/CustomKeyboard/KoreanKeyboard/View/Components/KeyButton.swift
+++ b/CustomKeyboard/KoreanKeyboard/View/Components/KeyButton.swift
@@ -9,25 +9,8 @@ import UIKit
 
 final class KeyButtonView: UIView {
     
-    var keyButton: UIButton!
-    
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        buttonConfigure()
-        setUpKeyButtonLayout()
-    }
-    
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
-    }
-    
-    convenience init(_ title: String) {
-        self.init(frame: .zero)
-        keyButton.setTitle(title, for: .normal)
-    }
-    
-    private func buttonConfigure() {
-        keyButton = UIButton()
+    var keyButton: UIButton = {
+        let keyButton = UIButton()
         if #available(iOS 15.0, *) {
             var buttonConfig = UIButton.Configuration.filled()
             var buttonTitleAttribute = AttributedString()
@@ -46,7 +29,24 @@ final class KeyButtonView: UIView {
             keyButton.setTitleColor(.white, for: .normal)
             keyButton.layer.cornerRadius = Size.keyRadius
         }
+        return keyButton
+    }()
+    var keyValue: KeyModel
+    var tmp = "hi"
+    
+    
+    init(key: KeyModel) {
+        keyValue = key
+        super.init(frame: .zero)
+        
+        keyButton.setTitle(key.keyword, for: .normal)
+        setUpKeyButtonLayout()
     }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
 }
 
 private extension KeyButtonView {
@@ -61,6 +61,3 @@ private extension KeyButtonView {
         ])
     }
 }
-
-
-

--- a/CustomKeyboard/KoreanKeyboard/View/Components/PaddingView.swift
+++ b/CustomKeyboard/KoreanKeyboard/View/Components/PaddingView.swift
@@ -1,0 +1,30 @@
+//
+//  PaddingView.swift
+//  KoreanKeyboard
+//
+//  Created by 한택환 on 2023/07/13.
+//
+
+import UIKit
+
+final class PaddingView: UIView {
+    var keyItemCount: Int
+    
+    init(_ keyItemCount: Int) {
+        self.keyItemCount = keyItemCount
+        super.init(frame: .zero)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension PaddingView {
+    func setUpPaddingViewLayout() {
+        self.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.widthAnchor.constraint(equalToConstant: Size.firstKeyLeadingSpacing(keyItemCount))
+        ])
+    }
+}

--- a/CustomKeyboard/KoreanKeyboard/View/KeyboardView.swift
+++ b/CustomKeyboard/KoreanKeyboard/View/KeyboardView.swift
@@ -7,18 +7,24 @@
 
 import UIKit
 
+protocol KeyboardViewDelegate: AnyObject {
+    func setKeyAction(key: KeyModel)
+}
+
+
 class KeyboardView: UIView {
     
     lazy var keyboardStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
-        stackView.spacing = 0
+        stackView.spacing = .zero
         stackView.backgroundColor = .darkGray
         stackView.layoutMargins = Size.keyboardEdgeInsets()
         stackView.isLayoutMarginsRelativeArrangement = true
         stackView.distribution = .fillEqually
         return stackView
     }()
+    weak var delegate: KeyboardViewDelegate?
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -38,12 +44,13 @@ class KeyboardView: UIView {
         rowStackView.alignment = .fill
         
         keyRow.forEach { key in
-            let button = KeyButtonView(key.keyword)
+            let keyButtonView = KeyButtonView(key: key)
+            keyButtonView.keyButton.addTarget(self, action: #selector(keyButtonPressed), for: .touchUpInside)
             if key.uniValue < 100{
-                button.widthAnchor.constraint(equalToConstant: Size.keyWidth).isActive = true
-                button.heightAnchor.constraint(equalToConstant: Size.keyWidth * 1.35).isActive = true
+                keyButtonView.widthAnchor.constraint(equalToConstant: Size.keyWidth).isActive = true
+                keyButtonView.heightAnchor.constraint(equalToConstant: Size.keyWidth * 1.35).isActive = true
             }
-            rowStackView.addArrangedSubview(button)
+            rowStackView.addArrangedSubview(keyButtonView)
         }
         return rowStackView
     }
@@ -55,7 +62,8 @@ class KeyboardView: UIView {
         
         var firstKeyView: KeyButtonView?
         keyRow.forEach { key in
-            let keyButtonView = KeyButtonView(key.keyword)
+            let keyButtonView = KeyButtonView(key: key)
+            keyButtonView.keyButton.addTarget(self, action: #selector(keyButtonPressed), for: .touchUpInside)
             keyboardRowView.addSubview(keyButtonView)
             keyButtonView.translatesAutoresizingMaskIntoConstraints = false
             
@@ -82,6 +90,10 @@ class KeyboardView: UIView {
             } ? setUpRowView(keyRow: row) : setUpRowStackView(keyRow: row)
             keyboardStackView.addArrangedSubview(rowView)
         }
+    }
+    
+    @objc func keyButtonPressed(_ sender: KeyButtonView) {
+        delegate?.setKeyAction(key: sender.keyValue)
     }
 }
 

--- a/CustomKeyboard/KoreanKeyboard/View/KeyboardView.swift
+++ b/CustomKeyboard/KoreanKeyboard/View/KeyboardView.swift
@@ -17,11 +17,11 @@ class KeyboardView: UIView {
     lazy var keyboardStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
-        stackView.spacing = .zero
+        stackView.spacing = Size.keyRowSpacing
         stackView.backgroundColor = .darkGray
         stackView.layoutMargins = Size.keyboardEdgeInsets()
         stackView.isLayoutMarginsRelativeArrangement = true
-        stackView.distribution = .fillEqually
+        stackView.distribution = .equalCentering
         return stackView
     }()
     weak var delegate: KeyboardViewDelegate?
@@ -39,60 +39,40 @@ class KeyboardView: UIView {
     private func setUpRowStackView(keyRow: [KeyModel]) -> UIStackView {
         let rowStackView = UIStackView()
         rowStackView.axis = .horizontal
-        rowStackView.spacing = 0
+        rowStackView.spacing = Size.keyItemSpacing
         rowStackView.distribution = keyRow.count <= 4 ? .fillProportionally : .equalSpacing
         rowStackView.alignment = .fill
         
         keyRow.forEach { key in
-            let keyButtonView = KeyButtonView(key: key)
-            keyButtonView.keyButton.addTarget(self, action: #selector(keyButtonPressed), for: .touchUpInside)
-            if key.uniValue < 100{
-                keyButtonView.widthAnchor.constraint(equalToConstant: Size.keyWidth).isActive = true
-                keyButtonView.heightAnchor.constraint(equalToConstant: Size.keyWidth * 1.35).isActive = true
+            let keyButton = KeyButton(key: key)
+            keyButton.addTarget(self, action: #selector(keyButtonPressed), for: .touchUpInside)
+            if key.uniValue < 100 {
+                keyButton.widthAnchor.constraint(equalToConstant: Size.keyWidth).isActive = true
+                keyButton.heightAnchor.constraint(equalToConstant: Size.keyWidth * 1.35).isActive = true
+            } else if key.uniValue == 101 {
+                keyButton.widthAnchor.constraint(equalToConstant: Size.keyWidth * 2).isActive = true
             }
-            rowStackView.addArrangedSubview(keyButtonView)
+            if key.keyword == "ㅁ" {
+                let paddingView = PaddingView(keyRow.count)
+                rowStackView.addArrangedSubview(paddingView)
+            }
+            rowStackView.addArrangedSubview(keyButton)
+            if key.keyword == "ㅣ" {
+                let paddingView = PaddingView(keyRow.count)
+                rowStackView.addArrangedSubview(paddingView)
+            }
         }
         return rowStackView
     }
     
-    private func setUpRowView(keyRow: [KeyModel]) -> UIView {
-        let keyboardRowView = UIView()
-        let leadingSpacing = (Size.width - Size.keyWidth * CGFloat(keyRow.count)) / 2
-        keyboardRowView.widthAnchor.constraint(equalToConstant: Size.width).isActive = true
-        
-        var firstKeyView: KeyButtonView?
-        keyRow.forEach { key in
-            let keyButtonView = KeyButtonView(key: key)
-            keyButtonView.keyButton.addTarget(self, action: #selector(keyButtonPressed), for: .touchUpInside)
-            keyboardRowView.addSubview(keyButtonView)
-            keyButtonView.translatesAutoresizingMaskIntoConstraints = false
-            
-            if let firstKeyView = firstKeyView {
-                keyButtonView.leadingAnchor.constraint(equalTo: firstKeyView.trailingAnchor).isActive = true
-            } else {
-                keyButtonView.leadingAnchor.constraint(equalTo: keyboardRowView.leadingAnchor, constant: leadingSpacing).isActive = true
-            }
-            keyButtonView.topAnchor.constraint(equalTo: keyboardRowView.topAnchor).isActive = true
-            keyButtonView.bottomAnchor.constraint(equalTo: keyboardRowView.bottomAnchor).isActive = true
-            keyButtonView.widthAnchor.constraint(equalToConstant: Size.keyWidth).isActive = true
-            keyButtonView.heightAnchor.constraint(equalToConstant: Size.keyWidth * 1.35).isActive = true
-            
-            firstKeyView = keyButtonView
-        }
-        return keyboardRowView
-    }
-    
-    
     private func setUpKeyboardStackView() {
         for row in keys {
-            let rowView = row.contains { key in
-                key.keyword == "ㅁ"
-            } ? setUpRowView(keyRow: row) : setUpRowStackView(keyRow: row)
+            let rowView = setUpRowStackView(keyRow: row)
             keyboardStackView.addArrangedSubview(rowView)
         }
     }
     
-    @objc func keyButtonPressed(_ sender: KeyButtonView) {
+    @objc func keyButtonPressed(_ sender: KeyButton) {
         delegate?.setKeyAction(key: sender.keyValue)
     }
 }


### PR DESCRIPTION
# KeyboardView의 UI 구성을 변경합니다
전반적인 UI의 변화는 #4 와 차이가 없지만 #4 에서 활용한 UIView와 UIStackView중 UIStackView만을 활용하도록 구현하여 불필요한 코드를 줄이고 유지보수를 간편하게 할 수 있도록 노력하였습니다.

변경 사항은 아래와 같습니다.
- UI 구성 변화
- KeyButtonView -> KeyButton 으로 UIView에서 UIButton으로 변경
- Literal 수정
- PaddingView 구현
- setUpRowView() 삭제 및 통합

### UI 구성 변화
#4 의 기존 구성에는 `UIButtonView`로 `UIView`가 `UIButton`을 감싸는 방식으로 구현하였습니다.
그러나 이 경우에 `Controller`에서 `UIButtonView`의 이벤트 수신을 대리자 역할로 처리하는 delegate 패턴이 동작하기에 어려움이 있었습니다.
`UIButtonView`를 갖는 `KeyboardView`에서 delegate을 선언하고 `KeyboardViewController`에서 대리자 역할로 처리하려고 하였으나
`KeyboardView`에서 `UIButtonView` -> `keyButton`으로 접근하게 되는 경우 `sender`의 역할이 제대로 동작하지 않는 이슈가 있었습니다.
따라서 `Literal`에 Key 사이의 Padding을 따로 추가하고 Padding을 `RowStackView`의 `Spacing`으로 주는 방식으로 변환하였습니다.
또한 두번째 Row의 경우에는 PaddingView를 따로 만들어 경우에 따라서 추가함으로써 버튼의 정렬이 기본 키보드 UI와 동일하도록 구현하였습니다.



## KeyButtonView -> KeyButton
`UIView`에서 `UIButton`으로 변경하였습니다.
Delegate패턴으로 Key 눌렸을 시 이벤트를 처리하는 과정에서 `KeyboardView`의 delegate을 선언하고 `KeyButtonView.keyButton`이 delegate으로 전달되는 액션을 받게 될시에 `sender`는 `KeyButtonView`가 되면서 액션을 받은 `keyButton`의 Key값이 제대로 전달 되지 않는 이슈로 인해서 변경하였습니다.


## Literal 수정
위에서 언급하였듯이 `UIButton`으로 변경하면서 기존의 Padding은 `Literal`에 새로 추가하여 `StackView`들의 `Spacing`으로 들어갑니다.
```swift
    static let keyWidth = width / CGFloat(keys.first?.count ?? 10) - keyItemSpacing
    static let keyItemSpacing: CGFloat = 6
    static let keyRowSpacing: CGFloat = 10
    
    static func firstKeyLeadingSpacing(_ keyItemCount: Int) -> CGFloat {
        return (CGFloat(((keys.first?.count ?? 10) - keyItemCount)) * (Size.keyWidth + Size.keyItemSpacing)) / 2 - keyItemSpacing
    }
```

## PaddingView 구현
키보드 두번째 Row의 양옆 `PaddingView`를 구현합니다.
양옆에만 사용하고 있지만 Row의 Key 수에 따라 다른 경우에도 사용하여 가운데 정렬할 수 있도록 매개변수를 받아 구현하였습니다.

```swift
        NSLayoutConstraint.activate([
            self.widthAnchor.constraint(equalToConstant: Size.firstKeyLeadingSpacing(keyItemCount))
        ])
```
단순히 `width`만 값을 주었고 `KeyItemCount`는 상위뷰에서 특정 Row에 속하는 Key갯수를 받아서 전달됩니다.

## SetUpRowView() 삭제 및 통합
`PaddingView`를 활용하여 `UIStackView`여도 가운데정렬 및 양옆 Padding을 구현할 수 있게되어 `RowView`를 삭제하였습니다.

`rowStackView`에서의 구현방법은 아래와 같습니다.

```swift
            if key.keyword == "ㅁ" {
                let paddingView = PaddingView(keyRow.count)
                rowStackView.addArrangedSubview(paddingView)
            }
            rowStackView.addArrangedSubview(keyButton)
            if key.keyword == "ㅣ" {
                let paddingView = PaddingView(keyRow.count)
                rowStackView.addArrangedSubview(paddingView)
            }
```
"ㅁ", "ㅣ" 가 `PaddingView`가 필요한 Row의 양끝 `keyword` 이므로 `keyword`를 식별하고 `PaddingView`를 만들어 `rowStackView`에 삽입합니다.

## 기타 
- delegate패턴 또한 구현하였으나 이번 PR에서는 UI 구성의 변경에 대한 부분을 리뷰하므로 후에 쌍자음, Shift 이벤트, `next button` 처리까지 모두 완료함으로써 UI 작업이 종료되게 되면 그때 같이 리뷰하겠습니다.