### PR TITLE
Keyboard의 Shift 이벤트, nextKeyboardButton을 구현합니다

### DIFF
--- a/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
+++ b/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 class KeyboardViewController: UIInputViewController {
     
     @IBOutlet var nextKeyboardButton: UIButton!
-    private let keyboardView = KeyboardView(frame: .zero)
+    private var keyboardView = KeyboardView(.normal)
     
     var shiftKeyState: ShiftKeyState = .normal
     
@@ -23,8 +23,6 @@ class KeyboardViewController: UIInputViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setUpKeyboardViewLayout()
-        keyboardView.frame = view.bounds
-        keyboardView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         keyboardView.delegate = self
         // Perform custom UI setup here
         self.nextKeyboardButton = UIButton(type: .system)
@@ -71,13 +69,21 @@ extension KeyboardViewController: KeyboardViewDelegate {
         let proxy = textDocumentProxy as UITextDocumentProxy
         switch key.uniValue {
         case 101:
-            keyboardView.backgroundColor = shiftKeyState == .normal ? .white : .systemGray
+            shiftKeyState = shiftKeyState == .normal ? .constant : .normal
+            resetKeyboardView()
         default:
             proxy.insertText(key.keyword)
+            shiftKeyState = .normal
+            resetKeyboardView()
         }
     }
     
-    
+    func resetKeyboardView() {
+        keyboardView.removeFromSuperview()
+        keyboardView = KeyboardView(shiftKeyState)
+        keyboardView.delegate = self
+        setUpKeyboardViewLayout()
+    }
 }
 
 private extension KeyboardViewController {

--- a/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
+++ b/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
@@ -9,8 +9,7 @@ import UIKit
 
 class KeyboardViewController: UIInputViewController {
     
-    @IBOutlet var nextKeyboardButton: UIButton!
-    private var keyboardView = KeyboardView(.normal)
+    private var keyboardView: KeyboardView!
     
     var shiftKeyState: ShiftKeyState = .normal
     
@@ -21,26 +20,15 @@ class KeyboardViewController: UIInputViewController {
     }
     
     override func viewDidLoad() {
+
         super.viewDidLoad()
         setUpKeyboardViewLayout()
         keyboardView.delegate = self
         // Perform custom UI setup here
-        self.nextKeyboardButton = UIButton(type: .system)
-        
-        self.nextKeyboardButton.setTitle(NSLocalizedString("Next Keyboard", comment: "Title for 'Next Keyboard' button"), for: [])
-        self.nextKeyboardButton.sizeToFit()
-        self.nextKeyboardButton.translatesAutoresizingMaskIntoConstraints = false
-        
-        self.nextKeyboardButton.addTarget(self, action: #selector(handleInputModeList(from:with:)), for: .allTouchEvents)
-        
-        self.view.addSubview(self.nextKeyboardButton)
-        
-        self.nextKeyboardButton.leftAnchor.constraint(equalTo: self.view.leftAnchor).isActive = true
-        self.nextKeyboardButton.bottomAnchor.constraint(equalTo: self.view.bottomAnchor).isActive = true
     }
     
     override func viewWillLayoutSubviews() {
-        self.nextKeyboardButton.isHidden = !self.needsInputModeSwitchKey
+        //self.nextKeyboardButton.isHidden = !self.needsInputModeSwitchKey
         super.viewWillLayoutSubviews()
     }
     
@@ -58,7 +46,6 @@ class KeyboardViewController: UIInputViewController {
         } else {
             textColor = UIColor.black
         }
-        self.nextKeyboardButton.setTitleColor(textColor, for: [])
     }
 
 }
@@ -71,6 +58,8 @@ extension KeyboardViewController: KeyboardViewDelegate {
         case 101:
             shiftKeyState = shiftKeyState == .normal ? .constant : .normal
             resetKeyboardView()
+        case 100:
+            advanceToNextInputMode()
         default:
             proxy.insertText(key.keyword)
             shiftKeyState = .normal
@@ -80,7 +69,7 @@ extension KeyboardViewController: KeyboardViewDelegate {
     
     func resetKeyboardView() {
         keyboardView.removeFromSuperview()
-        keyboardView = KeyboardView(shiftKeyState)
+        keyboardView = KeyboardView(shiftKeyState, !self.needsInputModeSwitchKey)
         keyboardView.delegate = self
         setUpKeyboardViewLayout()
     }
@@ -88,6 +77,7 @@ extension KeyboardViewController: KeyboardViewDelegate {
 
 private extension KeyboardViewController {
     func setUpKeyboardViewLayout() {
+        keyboardView = KeyboardView(.normal, !self.needsInputModeSwitchKey)
         view.addSubview(keyboardView)
         keyboardView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([

--- a/CustomKeyboard/KoreanKeyboard/Model/KeyModel.swift
+++ b/CustomKeyboard/KoreanKeyboard/Model/KeyModel.swift
@@ -17,10 +17,27 @@ enum ShiftKeyState {
     case constant
 }
 
+func getConstantKey(_ key: KeyModel) -> KeyModel {
+    switch key.keyword {
+    case "ㅂ":
+        return KeyModel(keyword: "ㅃ", uniValue: 8)
+    case "ㄱ":
+        return KeyModel(keyword: "ㄲ", uniValue: 1)
+    case "ㄷ":
+        return KeyModel(keyword: "ㄸ", uniValue: 4)
+    case "ㅈ":
+        return KeyModel(keyword: "ㅉ", uniValue: 13)
+    case "ㅅ":
+        return KeyModel(keyword: "ㅆ", uniValue: 10)
+    default:
+        return key
+    }
+}
+
 //추후 한글 조합을 위한 유니코드 uniValue 변경 예정
 let keys: [[KeyModel]] = [
         [KeyModel(keyword: "ㅂ", uniValue: 7), KeyModel(keyword: "ㅈ", uniValue: 0), KeyModel(keyword: "ㄷ", uniValue: 0), KeyModel(keyword: "ㄱ", uniValue: 0), KeyModel(keyword: "ㅅ", uniValue: 0), KeyModel(keyword: "ㅛ", uniValue: 0), KeyModel(keyword: "ㅕ", uniValue: 0), KeyModel(keyword: "ㅑ", uniValue: 0), KeyModel(keyword: "ㅐ", uniValue: 0), KeyModel(keyword: "ㅔ", uniValue: 0)],
         [KeyModel(keyword: "ㅁ", uniValue: 0), KeyModel(keyword: "ㄴ", uniValue: 0), KeyModel(keyword: "ㅇ", uniValue: 0), KeyModel(keyword: "ㄹ", uniValue: 0), KeyModel(keyword: "ㅎ", uniValue: 0), KeyModel(keyword: "ㅗ", uniValue: 0), KeyModel(keyword: "ㅓ", uniValue: 0), KeyModel(keyword: "ㅏ", uniValue: 0), KeyModel(keyword: "ㅣ", uniValue: 0)],
         [KeyModel(keyword: "Shift", uniValue: 101), KeyModel(keyword: "ㅋ", uniValue: 0), KeyModel(keyword: "ㅌ", uniValue: 0), KeyModel(keyword: "ㅊ", uniValue: 0), KeyModel(keyword: "ㅍ", uniValue: 0), KeyModel(keyword: "ㅠ", uniValue: 0), KeyModel(keyword: "ㅜ", uniValue: 0), KeyModel(keyword: "ㅡ", uniValue: 0), KeyModel(keyword: "⌫", uniValue: 102)],
-        [KeyModel(keyword: "🌐", uniValue: 100), KeyModel(keyword: "단축키", uniValue: 103), KeyModel(keyword: "Space", uniValue: 104), KeyModel(keyword: "Enter", uniValue: 105)]
+        [KeyModel(keyword: "🌐", uniValue: 99), KeyModel(keyword: "단축키", uniValue: 100), KeyModel(keyword: "Space", uniValue: 104), KeyModel(keyword: "Enter", uniValue: 105)]
     ]

--- a/CustomKeyboard/KoreanKeyboard/View/KeyboardView.swift
+++ b/CustomKeyboard/KoreanKeyboard/View/KeyboardView.swift
@@ -11,7 +11,6 @@ protocol KeyboardViewDelegate: AnyObject {
     func setKeyAction(key: KeyModel)
 }
 
-
 class KeyboardView: UIView {
     
     lazy var keyboardStackView: UIStackView = {
@@ -24,10 +23,13 @@ class KeyboardView: UIView {
         stackView.distribution = .equalCentering
         return stackView
     }()
-    weak var delegate: KeyboardViewDelegate?
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    weak var delegate: KeyboardViewDelegate?
+    var shiftState: ShiftKeyState
+    
+    init(_ shiftState: ShiftKeyState) {
+        self.shiftState = shiftState
+        super.init(frame: .zero)
         setUpKeyboardStackView()
         setUpKeyboardStackViewLayout()
     }
@@ -44,13 +46,17 @@ class KeyboardView: UIView {
         rowStackView.alignment = .fill
         
         keyRow.forEach { key in
-            let keyButton = KeyButton(key: key)
+            let keyButton = shiftState == .constant ? KeyButton(key: getConstantKey(key)) : KeyButton(key: key)
             keyButton.addTarget(self, action: #selector(keyButtonPressed), for: .touchUpInside)
-            if key.uniValue < 100 {
+            if key.uniValue <= 100 {
                 keyButton.widthAnchor.constraint(equalToConstant: Size.keyWidth).isActive = true
                 keyButton.heightAnchor.constraint(equalToConstant: Size.keyWidth * 1.35).isActive = true
             } else if key.uniValue == 101 {
                 keyButton.widthAnchor.constraint(equalToConstant: Size.keyWidth * 2).isActive = true
+                var shiftButtonConfig = UIButton.Configuration.filled()
+                shiftButtonConfig.baseBackgroundColor = shiftState == .constant ? .white : .systemGray
+                shiftButtonConfig.baseForegroundColor = shiftState == .constant ? .systemGray : .white
+                keyButton.configuration = shiftButtonConfig
             }
             if key.keyword == "ㅁ" {
                 let paddingView = PaddingView(keyRow.count)

--- a/CustomKeyboard/KoreanKeyboard/View/KeyboardView.swift
+++ b/CustomKeyboard/KoreanKeyboard/View/KeyboardView.swift
@@ -26,9 +26,11 @@ class KeyboardView: UIView {
     
     weak var delegate: KeyboardViewDelegate?
     var shiftState: ShiftKeyState
+    var switchKeyState: Bool
     
-    init(_ shiftState: ShiftKeyState) {
+    init(_ shiftState: ShiftKeyState, _ switchKeyState: Bool) {
         self.shiftState = shiftState
+        self.switchKeyState = switchKeyState
         super.init(frame: .zero)
         setUpKeyboardStackView()
         setUpKeyboardStackViewLayout()
@@ -48,15 +50,20 @@ class KeyboardView: UIView {
         keyRow.forEach { key in
             let keyButton = shiftState == .constant ? KeyButton(key: getConstantKey(key)) : KeyButton(key: key)
             keyButton.addTarget(self, action: #selector(keyButtonPressed), for: .touchUpInside)
-            if key.uniValue <= 100 {
+            
+            switch key.uniValue {
+            case 0..<100:
                 keyButton.widthAnchor.constraint(equalToConstant: Size.keyWidth).isActive = true
                 keyButton.heightAnchor.constraint(equalToConstant: Size.keyWidth * 1.35).isActive = true
-            } else if key.uniValue == 101 {
+            case 101:
                 keyButton.widthAnchor.constraint(equalToConstant: Size.keyWidth * 2).isActive = true
                 var shiftButtonConfig = UIButton.Configuration.filled()
                 shiftButtonConfig.baseBackgroundColor = shiftState == .constant ? .white : .systemGray
                 shiftButtonConfig.baseForegroundColor = shiftState == .constant ? .systemGray : .white
                 keyButton.configuration = shiftButtonConfig
+            case 100:
+                keyButton.isHidden = switchKeyState
+            default: break
             }
             if key.keyword == "ㅁ" {
                 let paddingView = PaddingView(keyRow.count)


### PR DESCRIPTION
# Keyboard의 Shift 이벤트, nextKeyboardButton을 구현합니다
구현 사항
- Shift를 누를 시에 Shift가 변화하고 쌍자음으로 바뀌는 UI를 구현합니다.
- nextKeyboardButton의 기능을 KeyButton으로 구현합니다.

## Shift 이벤트 구현
KeyboardView 내부의 KeyButton에서 사용자 액션을 수신할 시에 KeyboardView의 delegate 메소드로 전달되고 KeyboardViewController에서 이벤트를 처리하도록 하여 구현하였습니다.

ShiftKeyState라는 enum을 만들어 shift가 눌린 경우 .constant 눌리지 않은 경우 .normal로 설정합니다.

설정은 KeyboardView에 전달되고 KeyboardView의 setUpRowStackView()에서는 
```swift
let keyButton = shiftState == .constant ? KeyButton(key: getConstantKey(key)) : KeyButton(key: key)
```
로 keyButton을 shiftState에 따라서 KeyButton에 전달되는 key를 쌍자음으로 생성할지에 대한 여부를 결정합니다.

쌍자음으로 변경하는 메소드는 `getConstantKey()`로 전달받은 key.keyword가 쌍자음으로 변경이 가능하다면 변경된 key를 반환하는 메소드입니다.

또한 Shift 키의 경우
```swift
            case 101:
                keyButton.widthAnchor.constraint(equalToConstant: Size.keyWidth * 2).isActive = true
                var shiftButtonConfig = UIButton.Configuration.filled()
                shiftButtonConfig.baseBackgroundColor = shiftState == .constant ? .white : .systemGray
                shiftButtonConfig.baseForegroundColor = shiftState == .constant ? .systemGray : .white
                keyButton.configuration = shiftButtonConfig
```
전달받은 shiftState에 따라서 배경색과 글꼴 색을 변경하게 됩니다.

KeyboardView의 설정을 변경한 이후에는 
```swift
    func resetKeyboardView() {
        keyboardView.removeFromSuperview()
        keyboardView = KeyboardView(shiftKeyState, !self.needsInputModeSwitchKey)
        keyboardView.delegate = self
        setUpKeyboardViewLayout()
    }
```
위의 메소드를 통해 KeyboardViewController에서 변경된 설정의 keyboardView를 재구성합니다.

추가적으로 다른 키를 누를 시에도 shiftState를 .normal로 초기화하고 resetKeyboardView()를 호출하도록 하여 shift 상태가 원래대로 돌아가도록 구현하였습니다.

## nextKeyboardButton을 구현하였습니다.
nextKeyboardButton은 Keyboard Extension에 기본적으로 포함되어있는 것으로 다른 키보드로의 전환을 할 수 있는 기능을 제공합니다.

nextKeyboardButton을 따로 KeyboardView에서 구현하였습니다.
`self.needsInputModeSwitchKey` 는 nextKeyboardButton의 hidden을 담당하는 메소드로 홈버튼이 없는 기종의 경우 자체적으로 지원되기 때문에 false 가 반환되고 구현할 필요가 없습니다.

따라서 이 메소드를 KeyboardView로 전달 후에 
```swift
case 100:
   keyButton.isHidden = switchKeyState
```
메소드의 값에 따라서 hidden을 결정합니다.

또한 hidden이 되지 않는 경우

```swift
case 100:
    advanceToNextInputMode()
```
를 위의 delegate 패턴에서 전달하여 🌐 버튼을 누를 시에 다음 키보드로 넘어가는 기능을 구현하였습니다.

홈버튼 있는 기기와 없는 기기 모두 확인하였습니다.

UI구현은 모두 종료되었습니다.
한글 오토마타와 단축키, 자주쓰는 말을 구현할 예정입니다.

## 참고
https://developer.apple.com/documentation/uikit/uiinputviewcontroller/1618191-advancetonextinputmode
