### PR TITLE
입력 시 한글 조합과 조합된 한글로 입력되는 기능을 구현하였습니다

### DIFF
--- a/CustomKeyboard/CustomKeyboard.xcodeproj/project.pbxproj
+++ b/CustomKeyboard/CustomKeyboard.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		2A2C9B5E2A607E2A0021DD33 /* FrequentlyUsedPhrasesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A2C9B5D2A607E2A0021DD33 /* FrequentlyUsedPhrasesView.swift */; };
 		2A2C9B602A608DCC0021DD33 /* FrequentlyUsedPhrasesLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A2C9B5F2A608DCC0021DD33 /* FrequentlyUsedPhrasesLabel.swift */; };
 		2A2C9B622A61158F0021DD33 /* Value.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A2C9B612A61158F0021DD33 /* Value.swift */; };
+		2A2D4AE42A618D290089FE29 /* Hangul.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A2D4AE32A618D290089FE29 /* Hangul.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -97,6 +98,7 @@
 		2A2C9B5D2A607E2A0021DD33 /* FrequentlyUsedPhrasesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrequentlyUsedPhrasesView.swift; sourceTree = "<group>"; };
 		2A2C9B5F2A608DCC0021DD33 /* FrequentlyUsedPhrasesLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrequentlyUsedPhrasesLabel.swift; sourceTree = "<group>"; };
 		2A2C9B612A61158F0021DD33 /* Value.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Value.swift; sourceTree = "<group>"; };
+		2A2D4AE32A618D290089FE29 /* Hangul.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hangul.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -235,6 +237,7 @@
 			children = (
 				2A2C9B4F2A5E67540021DD33 /* Size.swift */,
 				2A2C9B612A61158F0021DD33 /* Value.swift */,
+				2A2D4AE32A618D290089FE29 /* Hangul.swift */,
 			);
 			path = Literal;
 			sourceTree = "<group>";
@@ -471,6 +474,7 @@
 				2A2C9B5C2A607A9B0021DD33 /* FrequentlyUsedPhrasesButton.swift in Sources */,
 				2A2C9B5A2A6075E20021DD33 /* ToolbarView.swift in Sources */,
 				2A2C9B552A603CD60021DD33 /* PaddingView.swift in Sources */,
+				2A2D4AE42A618D290089FE29 /* Hangul.swift in Sources */,
 				2A2C9AE22A5C61730021DD33 /* KeyboardViewController.swift in Sources */,
 				2A2C9B602A608DCC0021DD33 /* FrequentlyUsedPhrasesLabel.swift in Sources */,
 				2A2C9AED2A5C618A0021DD33 /* KeyModel.swift in Sources */,
@@ -569,7 +573,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -623,7 +627,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;

--- a/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
+++ b/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
@@ -85,6 +85,7 @@ extension KeyboardViewController: KeyboardViewDelegate {
             inputState = 0
         default:
             handleKeyInput(key)
+            print("case : ", inputState, "버퍼 : ", buffer)
             if shiftKeyState == .constant {
                 shiftKeyState = .normal
                 resetKeyboardView()
@@ -156,7 +157,7 @@ private extension KeyboardViewController {
 }
 
 private extension KeyboardViewController {
-
+    
     func makeWord(_ cho: Int, _ jung: Int, _ jong: Int) -> String {
         guard let result = UnicodeScalar(0xAC00 + 28 * 21 * cho + 28 * jung  + jong) else { return "오류가 발생했습니다." }
         return String(Character(result))
@@ -169,23 +170,39 @@ private extension KeyboardViewController {
         }
         
         switch inputState {
-        case 0:
+        case 0: // 중성만 입력하면 다시 중성 입력할 수도 있는 부분
             if Hangul.jungs.contains(key.keyword) {
-                textDocumentProxy.insertText(key.keyword)
+                if !buffer.isEmpty {
+                    let doubleJung = Hangul.makeJungDoublePhoneme(buffer.last!, key).keyword
+                    if doubleJung != key.keyword {
+                        textDocumentProxy.deleteBackward()
+                        textDocumentProxy.insertText(doubleJung)
+                        buffer.removeAll()
+                    }
+                    else {
+                        textDocumentProxy.insertText(key.keyword)
+                        buffer.removeAll()
+                        buffer.append(key)
+                    }
+                } else {
+                    textDocumentProxy.insertText(key.keyword)
+                    buffer.append(key)
+                }
             } else {
                 textDocumentProxy.insertText(key.keyword)
                 buffer.append(key)
                 inputState = 1
             }
-        case 1:
+        case 1: // 정상이라면 중성을 입력하는 부분
             if Hangul.jungs.contains(key.keyword) {
                 guard let cho = buffer.last else { return }
                 if buffer.count == 1 {
                     textDocumentProxy.deleteBackward()
-                } else {
+                } else { // DoubleJong으로 이루어진 것
                     textDocumentProxy.deleteBackward()
-                    let chojungjong = Array(buffer.suffix(3))
-                    textDocumentProxy.insertText(makeWord(chojungjong[0].uniValue, chojungjong[1].uniValue, 0))
+                    let chojungjong = Array(buffer.suffix(4))
+                    let jong = Hangul.makeJongDoublePhoneme(chojungjong[2], KeyModel(keyword: "", uniValue: 0))
+                    textDocumentProxy.insertText(makeWord(chojungjong[0].uniValue, chojungjong[1].uniValue, jong.uniValue))
                 }
                 textDocumentProxy.insertText(makeWord(cho.uniValue, key.uniValue, 0))
                 buffer.append(key)
@@ -196,14 +213,23 @@ private extension KeyboardViewController {
                 buffer.append(key)
             }
         case 2:
+            let chojung = Array(buffer.suffix(2))
             if Hangul.jungs.contains(key.keyword) {
-                buffer.removeAll()
-                textDocumentProxy.insertText(key.keyword)
-                inputState = 0
+                //doubleJung을 확인
+                let doubleJung = Hangul.makeJungDoublePhoneme(chojung[1], key)
+                if doubleJung.keyword != key.keyword {
+                    textDocumentProxy.deleteBackward()
+                    textDocumentProxy.insertText(makeWord(chojung[0].uniValue, doubleJung.uniValue, 0))
+                    buffer.removeLast()
+                    buffer.append(doubleJung)
+                } else {
+                    buffer.removeAll()
+                    textDocumentProxy.insertText(key.keyword)
+                    inputState = 0
+                }
             } else {
-                let chojung = Array(buffer.suffix(2))
                 textDocumentProxy.deleteBackward()
-                textDocumentProxy.insertText(makeWord(chojung[0].uniValue, chojung[1].uniValue, Hangul.makeDoublePhoneme(key, KeyModel(keyword: "", uniValue: 0)).uniValue))
+                textDocumentProxy.insertText(makeWord(chojung[0].uniValue, chojung[1].uniValue, Hangul.makeJongDoublePhoneme(key, KeyModel(keyword: "", uniValue: 0)).uniValue))
                 if Hangul.jongs.contains(key.keyword) {
                     buffer.append(key)
                     inputState = 3
@@ -214,12 +240,13 @@ private extension KeyboardViewController {
             }
         case 3:
             let chojungjong = Array(buffer.suffix(3))
-            let doubleJong = Hangul.makeDoublePhoneme(chojungjong[2], key)
+            let doubleJong = Hangul.makeJongDoublePhoneme(chojungjong[2], key)
             print(doubleJong.keyword)
+            //doublejong이 참인경우
             if doubleJong.keyword != "" {
                 textDocumentProxy.deleteBackward()
                 textDocumentProxy.insertText(makeWord(chojungjong[0].uniValue, chojungjong[1].uniValue, doubleJong.uniValue))
-                buffer.removeAll()
+                //buffer.removeAll()
                 buffer.append(key)
                 inputState = 1
             }
@@ -231,7 +258,7 @@ private extension KeyboardViewController {
             } else if Hangul.jungs.contains(key.keyword) {
                 guard let cho = buffer.last else { return }
                 if buffer.count == 1 {
-                    textDocumentProxy.deleteBackward()
+                    //textDocumentProxy.deleteBackward()
                 } else {
                     textDocumentProxy.deleteBackward()
                     let chojungjong = Array(buffer.suffix(3))
@@ -245,9 +272,5 @@ private extension KeyboardViewController {
         default:
             break
         }
-    }
-    
-    func getDoubleJong(_ first: KeyModel, _ last: KeyModel) -> KeyModel {
-        return first
     }
 }

--- a/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
+++ b/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
@@ -177,7 +177,7 @@ private extension KeyboardViewController {
                     return
                 }
                 let doubleJung = Hangul.makeJungDoublePhoneme(firstJung, key).keyword
-                if doubleJung != key.keyword {
+                if doubleJung != "" {
                     textDocumentProxy.deleteBackward()
                     textDocumentProxy.insertText(doubleJung)
                     buffer.removeAll()
@@ -215,7 +215,7 @@ private extension KeyboardViewController {
             let chojung = Array(buffer.suffix(2))
             if Hangul.jungs.contains(key.keyword) {
                 let doubleJung = Hangul.makeJungDoublePhoneme(chojung[1], key)
-                if doubleJung.keyword != key.keyword {
+                if doubleJung.keyword != "" {
                     textDocumentProxy.deleteBackward()
                     textDocumentProxy.insertText(makeWord(chojung[0].uniValue, doubleJung.uniValue, 0))
                     buffer.removeLast()
@@ -228,13 +228,8 @@ private extension KeyboardViewController {
             } else {
                 textDocumentProxy.deleteBackward()
                 textDocumentProxy.insertText(makeWord(chojung[0].uniValue, chojung[1].uniValue, Hangul.makeJongDoublePhoneme(key, KeyModel(keyword: "", uniValue: 0)).uniValue))
-                if Hangul.jongs.contains(key.keyword) {
-                    buffer.append(key)
-                    inputState = 3
-                } else {
-                    buffer.append(key)
-                    inputState = 1
-                }
+                buffer.append(key)
+                inputState = 3
             }
         case 3:
             let chojungjong = Array(buffer.suffix(3))

--- a/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
+++ b/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
@@ -9,6 +9,9 @@ import UIKit
 
 class KeyboardViewController: UIInputViewController {
     
+    var buffer = [KeyModel]()
+    var inputState: Int = 0
+    
     private var keyboardView: KeyboardView!
     private var frequentlyUsedPhrasesView: FrequentlyUsedPhrasesView!
     private let toolbar = ToolbarView()
@@ -22,7 +25,7 @@ class KeyboardViewController: UIInputViewController {
     }
     
     override func viewDidLoad() {
-
+        
         super.viewDidLoad()
         keyboardView = KeyboardView(.normal, !self.needsInputModeSwitchKey)
         setUpToolBarLayout()
@@ -52,23 +55,40 @@ class KeyboardViewController: UIInputViewController {
             textColor = UIColor.black
         }
     }
-
+    
 }
 
 extension KeyboardViewController: KeyboardViewDelegate {
     
     func setKeyAction(key: KeyModel) {
-        let proxy = textDocumentProxy as UITextDocumentProxy
         switch key.uniValue {
+        case 100:
+            advanceToNextInputMode()
         case 101:
             shiftKeyState = shiftKeyState == .normal ? .constant : .normal
             resetKeyboardView()
-        case 100:
-            advanceToNextInputMode()
+        case 102:
+            textDocumentProxy.deleteBackward()
+            buffer.removeAll()
+            inputState = 0
+        case 103:
+            textDocumentProxy.insertText(key.keyword)
+            buffer.removeAll()
+            inputState = 0
+        case 104:
+            textDocumentProxy.insertText(" ")
+            buffer.removeAll()
+            inputState = 0
+        case 105:
+            textDocumentProxy.insertText("\n")
+            buffer.removeAll()
+            inputState = 0
         default:
-            proxy.insertText(key.keyword)
-            shiftKeyState = .normal
-            resetKeyboardView()
+            handleKeyInput(key)
+            if shiftKeyState == .constant {
+                shiftKeyState = .normal
+                resetKeyboardView()
+            }
         }
     }
     
@@ -121,7 +141,7 @@ private extension KeyboardViewController {
             keyboardView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
     }
-
+    
     func setUpFrequentlyUsedPhrasesViewLayout() {
         frequentlyUsedPhrasesView = FrequentlyUsedPhrasesView()
         view.addSubview(frequentlyUsedPhrasesView)
@@ -132,5 +152,102 @@ private extension KeyboardViewController {
             frequentlyUsedPhrasesView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             frequentlyUsedPhrasesView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
+    }
+}
+
+private extension KeyboardViewController {
+
+    func makeWord(_ cho: Int, _ jung: Int, _ jong: Int) -> String {
+        guard let result = UnicodeScalar(0xAC00 + 28 * 21 * cho + 28 * jung  + jong) else { return "오류가 발생했습니다." }
+        return String(Character(result))
+    }
+    
+    func handleKeyInput(_ key: KeyModel) {
+        if key.uniValue > 100 {
+            textDocumentProxy.insertText(key.keyword)
+            return
+        }
+        
+        switch inputState {
+        case 0:
+            if Hangul.jungs.contains(key.keyword) {
+                textDocumentProxy.insertText(key.keyword)
+            } else {
+                textDocumentProxy.insertText(key.keyword)
+                buffer.append(key)
+                inputState = 1
+            }
+        case 1:
+            if Hangul.jungs.contains(key.keyword) {
+                guard let cho = buffer.last else { return }
+                if buffer.count == 1 {
+                    textDocumentProxy.deleteBackward()
+                } else {
+                    textDocumentProxy.deleteBackward()
+                    let chojungjong = Array(buffer.suffix(3))
+                    textDocumentProxy.insertText(makeWord(chojungjong[0].uniValue, chojungjong[1].uniValue, 0))
+                }
+                textDocumentProxy.insertText(makeWord(cho.uniValue, key.uniValue, 0))
+                buffer.append(key)
+                inputState = 2
+            } else {
+                textDocumentProxy.insertText(key.keyword)
+                buffer.removeAll()
+                buffer.append(key)
+            }
+        case 2:
+            if Hangul.jungs.contains(key.keyword) {
+                buffer.removeAll()
+                textDocumentProxy.insertText(key.keyword)
+                inputState = 0
+            } else {
+                let chojung = Array(buffer.suffix(2))
+                textDocumentProxy.deleteBackward()
+                textDocumentProxy.insertText(makeWord(chojung[0].uniValue, chojung[1].uniValue, Hangul.makeDoublePhoneme(key, KeyModel(keyword: "", uniValue: 0)).uniValue))
+                if Hangul.jongs.contains(key.keyword) {
+                    buffer.append(key)
+                    inputState = 3
+                } else {
+                    buffer.append(key)
+                    inputState = 1
+                }
+            }
+        case 3:
+            let chojungjong = Array(buffer.suffix(3))
+            let doubleJong = Hangul.makeDoublePhoneme(chojungjong[2], key)
+            print(doubleJong.keyword)
+            if doubleJong.keyword != "" {
+                textDocumentProxy.deleteBackward()
+                textDocumentProxy.insertText(makeWord(chojungjong[0].uniValue, chojungjong[1].uniValue, doubleJong.uniValue))
+                buffer.removeAll()
+                buffer.append(key)
+                inputState = 1
+            }
+            else if Hangul.chos.contains(key.keyword) {
+                buffer.removeAll()
+                inputState = 1
+                textDocumentProxy.insertText(key.keyword)
+                buffer.append(key)
+            } else if Hangul.jungs.contains(key.keyword) {
+                guard let cho = buffer.last else { return }
+                if buffer.count == 1 {
+                    textDocumentProxy.deleteBackward()
+                } else {
+                    textDocumentProxy.deleteBackward()
+                    let chojungjong = Array(buffer.suffix(3))
+                    textDocumentProxy.insertText(makeWord(chojungjong[0].uniValue, chojungjong[1].uniValue, 0))
+                }
+                textDocumentProxy.insertText(makeWord(cho.uniValue, key.uniValue, 0))
+                inputState = 2
+                buffer.append(key)
+            }
+            
+        default:
+            break
+        }
+    }
+    
+    func getDoubleJong(_ first: KeyModel, _ last: KeyModel) -> KeyModel {
+        return first
     }
 }

--- a/CustomKeyboard/KoreanKeyboard/Literal/Hangul.swift
+++ b/CustomKeyboard/KoreanKeyboard/Literal/Hangul.swift
@@ -14,7 +14,31 @@ enum Hangul {
     static let jongs: Set<String> = [" ", "ㄱ", "ㄲ", "ㄳ", "ㄴ", "ㄵ", "ㄶ", "ㄷ", "ㄹ", "ㄺ", "ㄻ", "ㄼ", "ㄽ", "ㄾ", "ㄿ", "ㅀ", "ㅁ", "ㅂ", "ㅄ", "ㅅ", "ㅆ", "ㅇ", "ㅈ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ"]
     static let lastJongs: Set<String> = ["ㅅ", "ㅈ", "ㅎ", "ㄱ", "ㅁ", "ㅂ", "ㅌ", "ㅍ"]
     
-    static func makeDoublePhoneme(_ firstKey: KeyModel, _ lastKey: KeyModel) -> KeyModel {
+    static func makeJungDoublePhoneme(_ firstKey: KeyModel, _ lastKey: KeyModel) -> KeyModel {
+        let doublePhoneme: [String] = [firstKey.keyword, lastKey.keyword]
+        print(doublePhoneme)
+        
+        switch doublePhoneme {
+        case ["ㅗ", "ㅏ"]:
+            return KeyModel(keyword: "ㅘ", uniValue: 9)
+        case ["ㅗ", "ㅐ"]:
+            return KeyModel(keyword: "ㅙ", uniValue: 10)
+        case ["ㅗ", "ㅣ"]:
+            return KeyModel(keyword: "ㅚ", uniValue: 11)
+        case ["ㅜ", "ㅓ"]:
+            return KeyModel(keyword: "ㅝ", uniValue: 14)
+        case ["ㅜ", "ㅔ"]:
+            return KeyModel(keyword: "ㅞ", uniValue: 15)
+        case ["ㅜ", "ㅣ"]:
+            return KeyModel(keyword: "ㅟ", uniValue: 16)
+        case ["ㅡ", "ㅣ"]:
+            return KeyModel(keyword: "ㅢ", uniValue: 19)
+        default:
+            return lastKey
+        }
+    }
+    
+    static func makeJongDoublePhoneme(_ firstKey: KeyModel, _ lastKey: KeyModel) -> KeyModel {
         let doublePhoneme: [String] = [firstKey.keyword, lastKey.keyword]
         print(doublePhoneme)
         
@@ -77,6 +101,4 @@ enum Hangul {
             return KeyModel(keyword: "", uniValue: 0)
         }
     }
-
 }
-

--- a/CustomKeyboard/KoreanKeyboard/Literal/Hangul.swift
+++ b/CustomKeyboard/KoreanKeyboard/Literal/Hangul.swift
@@ -1,0 +1,82 @@
+//
+//  Hangul.swift
+//  KoreanKeyboard
+//
+//  Created by 한택환 on 2023/07/14.
+//
+
+import Foundation
+
+enum Hangul {
+    
+    static let chos: Set<String> = ["ㄱ", "ㄴ", "ㄷ", "ㄹ", "ㅁ", "ㅂ", "ㅅ", "ㅇ", "ㅈ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ", "ㄲ", "ㅃ", "ㅉ", "ㄸ", "ㅆ"]
+    static let jungs: Set<String> = ["ㅏ", "ㅑ", "ㅓ", "ㅕ", "ㅗ", "ㅛ", "ㅜ", "ㅠ", "ㅡ", "ㅣ", "ㅐ", "ㅒ", "ㅔ", "ㅖ"]
+    static let jongs: Set<String> = [" ", "ㄱ", "ㄲ", "ㄳ", "ㄴ", "ㄵ", "ㄶ", "ㄷ", "ㄹ", "ㄺ", "ㄻ", "ㄼ", "ㄽ", "ㄾ", "ㄿ", "ㅀ", "ㅁ", "ㅂ", "ㅄ", "ㅅ", "ㅆ", "ㅇ", "ㅈ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ"]
+    static let lastJongs: Set<String> = ["ㅅ", "ㅈ", "ㅎ", "ㄱ", "ㅁ", "ㅂ", "ㅌ", "ㅍ"]
+    
+    static func makeDoublePhoneme(_ firstKey: KeyModel, _ lastKey: KeyModel) -> KeyModel {
+        let doublePhoneme: [String] = [firstKey.keyword, lastKey.keyword]
+        print(doublePhoneme)
+        
+        switch doublePhoneme {
+        case ["ㄱ", ""]:
+            return KeyModel(keyword: "ㄱ", uniValue: 1)
+        case ["ㄲ", ""]:
+            return KeyModel(keyword: "ㄲ", uniValue: 2)
+        case ["ㄱ", "ㅅ"]:
+            return KeyModel(keyword: "ㄳ", uniValue: 3)
+        case ["ㄴ", ""]:
+            return KeyModel(keyword: "ㄴ", uniValue: 4)
+        case ["ㄴ", "ㅈ"]:
+            return KeyModel(keyword: "ㄵ", uniValue: 5)
+        case ["ㄴ", "ㅎ"]:
+            return KeyModel(keyword: "ㄶ", uniValue: 6)
+        case ["ㄷ", ""]:
+            return KeyModel(keyword: "ㄷ", uniValue: 7)
+        case ["ㄹ", ""]:
+            return KeyModel(keyword: "ㄹ", uniValue: 8)
+        case ["ㄹ", "ㄱ"]:
+            return KeyModel(keyword: "ㄺ", uniValue: 9)
+        case ["ㄹ", "ㅁ"]:
+            return KeyModel(keyword: "ㄻ", uniValue: 10)
+        case ["ㄹ", "ㅂ"]:
+            return KeyModel(keyword: "ㄼ", uniValue: 11)
+        case ["ㄹ", "ㅅ"]:
+            return KeyModel(keyword: "ㄽ", uniValue: 12)
+        case ["ㄹ", "ㅌ"]:
+            return KeyModel(keyword: "ㄾ", uniValue: 13)
+        case ["ㄹ", "ㅍ"]:
+            return KeyModel(keyword: "ㄿ", uniValue: 14)
+        case ["ㄹ", "ㅎ"]:
+            return KeyModel(keyword: "ㅀ", uniValue: 15)
+        case ["ㅁ", ""]:
+            return KeyModel(keyword: "ㅁ", uniValue: 16)
+        case ["ㅂ", ""]:
+            return KeyModel(keyword: "ㅂ", uniValue: 17)
+        case ["ㅂ", "ㅅ"]:
+            return KeyModel(keyword: "ㅄ", uniValue: 18)
+        case ["ㅅ", ""]:
+            return KeyModel(keyword: "ㅅ", uniValue: 19)
+        case ["ㅆ", ""]:
+            return KeyModel(keyword: "ㅆ", uniValue: 20)
+        case ["ㅇ", ""]:
+            return KeyModel(keyword: "ㅇ", uniValue: 21)
+        case ["ㅈ", ""]:
+            return KeyModel(keyword: "ㅈ", uniValue: 22)
+        case ["ㅊ", ""]:
+            return KeyModel(keyword: "ㅊ", uniValue: 23)
+        case ["ㅋ", ""]:
+            return KeyModel(keyword: "ㅋ", uniValue: 24)
+        case ["ㅌ", ""]:
+            return KeyModel(keyword: "ㅌ", uniValue: 25)
+        case ["ㅍ", ""]:
+            return KeyModel(keyword: "ㅍ", uniValue: 26)
+        case ["ㅎ", ""]:
+            return KeyModel(keyword: "ㅎ", uniValue: 27)
+        default:
+            return KeyModel(keyword: "", uniValue: 0)
+        }
+    }
+
+}
+

--- a/CustomKeyboard/KoreanKeyboard/Literal/Hangul.swift
+++ b/CustomKeyboard/KoreanKeyboard/Literal/Hangul.swift
@@ -33,7 +33,7 @@ enum Hangul {
         case ["ㅡ", "ㅣ"]:
             return KeyModel(keyword: "ㅢ", uniValue: 19)
         default:
-            return lastKey
+            return KeyModel(keyword: "", uniValue: 0)
         }
     }
     

--- a/CustomKeyboard/KoreanKeyboard/Literal/Hangul.swift
+++ b/CustomKeyboard/KoreanKeyboard/Literal/Hangul.swift
@@ -16,7 +16,6 @@ enum Hangul {
     
     static func makeJungDoublePhoneme(_ firstKey: KeyModel, _ lastKey: KeyModel) -> KeyModel {
         let doublePhoneme: [String] = [firstKey.keyword, lastKey.keyword]
-        print(doublePhoneme)
         
         switch doublePhoneme {
         case ["ㅗ", "ㅏ"]:
@@ -40,7 +39,6 @@ enum Hangul {
     
     static func makeJongDoublePhoneme(_ firstKey: KeyModel, _ lastKey: KeyModel) -> KeyModel {
         let doublePhoneme: [String] = [firstKey.keyword, lastKey.keyword]
-        print(doublePhoneme)
         
         switch doublePhoneme {
         case ["ㄱ", ""]:

--- a/CustomKeyboard/KoreanKeyboard/Model/KeyModel.swift
+++ b/CustomKeyboard/KoreanKeyboard/Model/KeyModel.swift
@@ -29,6 +29,10 @@ func getConstantKey(_ key: KeyModel) -> KeyModel {
         return KeyModel(keyword: "ㅉ", uniValue: 13)
     case "ㅅ":
         return KeyModel(keyword: "ㅆ", uniValue: 10)
+    case "ㅐ":
+        return KeyModel(keyword: "ㅒ", uniValue: 3)
+    case "ㅔ":
+        return KeyModel(keyword: "ㅖ", uniValue: 7)
     default:
         return key
     }
@@ -36,9 +40,9 @@ func getConstantKey(_ key: KeyModel) -> KeyModel {
 
 //추후 한글 조합을 위한 유니코드 uniValue 변경 예정
 let keys: [[KeyModel]] = [
-        [KeyModel(keyword: "ㅂ", uniValue: 7), KeyModel(keyword: "ㅈ", uniValue: 0), KeyModel(keyword: "ㄷ", uniValue: 0), KeyModel(keyword: "ㄱ", uniValue: 0), KeyModel(keyword: "ㅅ", uniValue: 0), KeyModel(keyword: "ㅛ", uniValue: 0), KeyModel(keyword: "ㅕ", uniValue: 0), KeyModel(keyword: "ㅑ", uniValue: 0), KeyModel(keyword: "ㅐ", uniValue: 0), KeyModel(keyword: "ㅔ", uniValue: 0)],
-        [KeyModel(keyword: "ㅁ", uniValue: 0), KeyModel(keyword: "ㄴ", uniValue: 0), KeyModel(keyword: "ㅇ", uniValue: 0), KeyModel(keyword: "ㄹ", uniValue: 0), KeyModel(keyword: "ㅎ", uniValue: 0), KeyModel(keyword: "ㅗ", uniValue: 0), KeyModel(keyword: "ㅓ", uniValue: 0), KeyModel(keyword: "ㅏ", uniValue: 0), KeyModel(keyword: "ㅣ", uniValue: 0)],
-        [KeyModel(keyword: "Shift", uniValue: 101), KeyModel(keyword: "ㅋ", uniValue: 0), KeyModel(keyword: "ㅌ", uniValue: 0), KeyModel(keyword: "ㅊ", uniValue: 0), KeyModel(keyword: "ㅍ", uniValue: 0), KeyModel(keyword: "ㅠ", uniValue: 0), KeyModel(keyword: "ㅜ", uniValue: 0), KeyModel(keyword: "ㅡ", uniValue: 0), KeyModel(keyword: "⌫", uniValue: 102)],
+        [KeyModel(keyword: "ㅂ", uniValue: 7), KeyModel(keyword: "ㅈ", uniValue: 12), KeyModel(keyword: "ㄷ", uniValue: 3), KeyModel(keyword: "ㄱ", uniValue: 0), KeyModel(keyword: "ㅅ", uniValue: 9), KeyModel(keyword: "ㅛ", uniValue: 12), KeyModel(keyword: "ㅕ", uniValue: 6), KeyModel(keyword: "ㅑ", uniValue: 2), KeyModel(keyword: "ㅐ", uniValue: 1), KeyModel(keyword: "ㅔ", uniValue: 5)],
+        [KeyModel(keyword: "ㅁ", uniValue: 6), KeyModel(keyword: "ㄴ", uniValue: 2), KeyModel(keyword: "ㅇ", uniValue: 11), KeyModel(keyword: "ㄹ", uniValue: 5), KeyModel(keyword: "ㅎ", uniValue: 18), KeyModel(keyword: "ㅗ", uniValue: 8), KeyModel(keyword: "ㅓ", uniValue: 4), KeyModel(keyword: "ㅏ", uniValue: 0), KeyModel(keyword: "ㅣ", uniValue: 20)],
+        [KeyModel(keyword: "Shift", uniValue: 101), KeyModel(keyword: "ㅋ", uniValue: 15), KeyModel(keyword: "ㅌ", uniValue: 16), KeyModel(keyword: "ㅊ", uniValue: 14), KeyModel(keyword: "ㅍ", uniValue: 17), KeyModel(keyword: "ㅠ", uniValue: 17), KeyModel(keyword: "ㅜ", uniValue: 13), KeyModel(keyword: "ㅡ", uniValue: 18), KeyModel(keyword: "⌫", uniValue: 102)],
         [KeyModel(keyword: "🌐", uniValue: 100), KeyModel(keyword: "단축키", uniValue: 103), KeyModel(keyword: "Space", uniValue: 104), KeyModel(keyword: "Enter", uniValue: 105)]
     ]
 


### PR DESCRIPTION
# 입력 시 한글 조합과 조합된 한글로 입력되는 기능을 구현하였습니다.
구현 사항
- Hangul Literal 구현
- 초성, 중성, 종성을 매개변수로 받아 조합된 단어를 반환하는 makeWord() 메소드 구현
- 상황에 맞게 한글을 조합시키고 textDocumentProxy.insert에 값을 전달하는 handleKeyInput() 메소드 구현
- controlKey 액션 발생 시 처리할 이벤트 구현

## 설계 화면
<img width="1000" alt="IMG_7762" src="https://github.com/TaekH/CustomKeyboard/assets/103012087/b37d5ba4-0b2a-4a6b-b9d8-2b615b76038d">

## 구현 화면

![한글입력](https://github.com/TaekH/CustomKeyboard/assets/103012087/c261f919-0af1-4e2e-86f6-b3c41ef5f43d)

## Hangul Literal 구현
Hangul Literal을 구현하였습니다.

초성, 중성, 종성의 문자를 모아놓은 Set과 이중 종성, 이중 중성을 계산하여 반환하는 메소드인 makeJungDoublePhoneme(), makeJongDoublePhoneme()를 구현하였습니다.

```swift
static let chos: Set<String> = ["ㄱ", "ㄴ", "ㄷ", "ㄹ", "ㅁ", "ㅂ", "ㅅ", "ㅇ", "ㅈ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ", "ㄲ", "ㅃ", "ㅉ", "ㄸ", "ㅆ"]
```

초성, 중성, 종성 Set의 경우 입력된 Key의 keyword가 초성, 중성, 종성인지를 확인하기 위해 구현하였습니다.
배열이 아닌 Set으로 구현한 이유는 .contains() 메소드를 사용할 시에 시간복잡도가 O(1)이기 때문입니다.


이중 종성, 이중 중성을 반환하는 메소드는 각각 첫번째, 두번째 종성과 중성을 받고 이중으로의 결합이 가능한 경우에 KeyModel을 만들어 반환합니다.
```swift
    static func makeJungDoublePhoneme(_ firstKey: KeyModel, _ lastKey: KeyModel) -> KeyModel {
        let doublePhoneme: [String] = [firstKey.keyword, lastKey.keyword]
        
        switch doublePhoneme {
        case ["ㅗ", "ㅏ"]:
            return KeyModel(keyword: "ㅘ", uniValue: 9)
        case ["ㅗ", "ㅐ"]:
            return KeyModel(keyword: "ㅙ", uniValue: 10)
        case ["ㅗ", "ㅣ"]:
            return KeyModel(keyword: "ㅚ", uniValue: 11)
        case ["ㅜ", "ㅓ"]:
            return KeyModel(keyword: "ㅝ", uniValue: 14)
        case ["ㅜ", "ㅔ"]:
            return KeyModel(keyword: "ㅞ", uniValue: 15)
        case ["ㅜ", "ㅣ"]:
            return KeyModel(keyword: "ㅟ", uniValue: 16)
        case ["ㅡ", "ㅣ"]:
            return KeyModel(keyword: "ㅢ", uniValue: 19)
        default:
            return lastKey
        }
    }
```
입력되는 문자가 "ㅢ"와 같은 문자이므로 어쩔 수 없이 모든 KeyModel을 Switch-Case문으로 구현하였습니다.

또한 이중이 불가능한 종성과 중성이 들어오게 되면 각각 비어있는 KeyModel을 반환하여 handleKeyInput() 메소드에서 분기처리를 할 수 있도록 하였습니다.

## makeWord() 메소드를 구현하였습니다.

KeyModel의 uniValue에 따라서 초성, 중성, 종성을 조합하여 단어를 반환하는 함수입니다.

```swift
    func makeWord(_ cho: Int, _ jung: Int, _ jong: Int) -> String {
        guard let result = UnicodeScalar(0xAC00 + 28 * 21 * cho + 28 * jung  + jong) else { return "오류가 발생했습니다." }
        return String(Character(result))
    }
```

## handleKeyInput() 메소드를 구현하였습니다.

handleKeyInput() 메소드는 각각의 case에 대해서 입력된 key를 조합하고 textDocumentProxy에 값을 삽입하여 TextField에 표시하도록 하는 메소드 입니다.

각각의 case에 대해 설명드리겠습니다.

> 각 key들은 조합 시 바로바로 textDocumentProxy에 전달해야 표시되기 때문에 조합을 하게 되면 이미 textDocumentProxy에 들어가있는 key의 경우 삭제 후에 조합하여 다시 삽입하는 과정을 거치게 됩니다.

> 또한 case는 inputState라는 변수에 따라 진행되며 case 별로 다음 단계의 case를 진행하기 위해서 inputState를 변환시키게 됩니다.

### case 0:
기본적으로 입력을 시작하지 않은 상태입니다. ( 중성만 입력된 상태일 수 있습니다.)
- key가 중성인 경우 
- 이전 입력한 buffer의 마지막 값을 확인합니다.
    - buffer 가 비어있는 경우 -> 키를 바로 입력하고 버퍼에 추가합니다.
    - 버퍼가 비어있지 않는 경우 -> 이전 중성과 현재 중성을 결합하여 이중 중성을 만들어줍니다. 
         - 이중 중성이 결합된 경우 -> 기존의 중성을 삭제하고 결합된 이중 중성을 입력합니다. 
         - 이중 중성이 결합되지 않은 경우 -> 기존 buffer를 초기화하고 현재 key만을 buffer에 추가합니다.

- key가 초성인 경우
    - 기존 buffer를 초기화하고 현재 key만을 buffer에 추가합니다, inputState = 1

### case 1:

초성이 입력된 상태입니다.

- key가 중성인 경우
    - buffer.last를 초성으로 설정합니다.
    - buffer <= 2 
        - 기존 proxy에 있는 문자를 삭제합니다.
        - 초성과 key를 결합하여 새로운 문자를 출력합니다.
        - buffer에 key를 추가합니다.
        - inputState = 2
    - else ( "값" 과 같은 case 3에서 넘어온 경우입니다.)
        - "값"과 같은 경우 buffer.last와 key를 따로 결합, 남은 갑 또한 재결합하여 "갑사"와 같은 문자로 변경합니다.
        - inputState = 2
- key가 중성이 아닌 경우
    - key를 출력합니다.
    - 기존 buffer를 초기화하고 현재 key만을 buffer에 추가합니다.


### case 2:

중성이 입력된 상태입니다.

- key가 중성인 경우
    - buffer.last와 key를 결합하여 이중 중성을 구현합니다.
    - 이중 중성이 결합되지 않은 경우 
        - 기존의 중성을 삭제하고 결합된 이중 중성을 입력합니다. 버퍼를 업데이트합니다.
    - 결합한 결과가 현재 키(key)와 동일한 경우: 버퍼를 초기화하고 키를 입력합니다.
- key가 중성이 아닌 경우
    - key를 종성으로 하여 이전 단어와 결합합니다.
    - buffer에 key를 추가합니다.
    - inputState = 3

### case 3:

종성이 입력된 상태입니다.

- key와 결합하여 이중 종성을 만들 수 있는 경우
    - 결합된 이중 종성을 단어로 재결합 한 뒤에 buffer에 key를 추가합니다, inputState = 1
- key와 결합하여 이중 종성을 만들 수 없는 경우
    - 입력된 키가 초성에 속하는 경우
        - buffer를 초기화합니다.
        - key를 출력합니다.
        - key를 버퍼에 추가 후, inputState = 1
    - 입력된 키가 중성에 속하는 경우:
        - buffer.last (기존 단어 종성) 과 key와 결합하여 새로운 단어를 생성하고 각각 출력합니다. ( "각" + "ㅏ" = "가가" )
        - inputState = 2

위와 같은 과정을 통해 한글을 조합하게 됩니다.

## Key 액션 발생 시 이벤트 구현

앞서 리뷰했던 #6 의 delegate 패턴에서 액션 발생 시 처리하는 부분에서의 구현입니다.
 코드 예시
```swift
        switch key.uniValue {
...
        case 105:
            textDocumentProxy.insertText("\n")
            buffer.removeAll()
            inputState = 0
        default:
            handleKeyInput(key)
            if shiftKeyState == .constant {
                shiftKeyState = .normal
                resetKeyboardView()
            }
        }
    }
```
각 ControlKey 별로 고유한 uniValue 를 가지고 있기 때문에 맞춰서 Switch - case 로 구현합니다.
각 ControlKey 마다 수행할 작업을 수행한 이후에 반드시 buffer와 inputState를 초기화하여 처음 입력부터 시작하도록 하였습니다.