### PR TITLE
삭제 시 음소 단위로 삭제되는 기능을 구현하였습니다

### DIFF
--- a/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
+++ b/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
@@ -340,13 +340,13 @@ extension KeyboardViewController {
                         let lastFourKeys = Array(buffer.suffix(4))
                         let doubleJong = Hangul.makeJongDoublePhoneme(lastFourKeys[2], lastFourKeys[3])
                         let word = makeWord(lastFourKeys[0], lastFourKeys[1], doubleJong)
-                            buffer.removeLast(2)
-                            buffer.append(doubleJong)
-                            if word != "" {
-                                textDocumentProxy.deleteBackward()
-                                textDocumentProxy.insertText(word)
-                                state = 1
-                            }
+                        buffer.removeLast(2)
+                        buffer.append(doubleJong)
+                        if word != "" {
+                            textDocumentProxy.deleteBackward()
+                            textDocumentProxy.insertText(word)
+                            state = 1
+                        }
                         
                     }
                     else {

--- a/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
+++ b/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
@@ -260,4 +260,13 @@ private extension KeyboardViewController {
             break
         }
     }
+    
+    func getPhonemeType(_ key: KeyModel) -> Int {
+        if Hangul.chos.contains(key.keyword) {
+            return 1
+        } else if Hangul.jungs.contains(key.keyword) {
+            return 2
+        }
+        return 0
+    }
 }

--- a/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
+++ b/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
@@ -71,6 +71,7 @@ extension KeyboardViewController: KeyboardViewDelegate {
     
     func resetState() {
         buffer.removeAll()
+        delBuffer.removeAll()
         state = 0
     }
     
@@ -168,12 +169,8 @@ private extension KeyboardViewController {
 private extension KeyboardViewController {
     
     func makeWord(_ cho: KeyModel, _ jung: KeyModel, _ jong: KeyModel) -> String {
-        print(Hangul.chos.contains(cho.keyword), cho)
-        print(Hangul.jungs.contains(jung.keyword), jung)
-        print(Hangul.jongs.contains(jong.keyword), jong)
         if Hangul.chos.contains(cho.keyword) && Hangul.jungs.contains(jung.keyword) && Hangul.jongs.contains(jong.keyword) {
-            guard let result = UnicodeScalar(0xAC00 + 28 * 21 * cho.uniValue + 28 * jung.uniValue  + jong.uniValue) else { return "오류가 발생했습니다." }
-            print(String(Character(result)))
+            guard let result = UnicodeScalar(0xAC00 + 28 * 21 * cho.uniValue + 28 * jung.uniValue  + jong.uniValue) else { return "" }
             return String(Character(result))
         }
         return ""
@@ -246,12 +243,12 @@ private extension KeyboardViewController {
             let chojung = Array(buffer.suffix(2))
             if Hangul.jungs.contains(key.keyword) {
                 let doubleJung = Hangul.makeJungDoublePhoneme(chojung[1], key)
-                if doubleJung.keyword != "" { //MARK: 이중 중성이 들어온 경우
+                if doubleJung.keyword != "" {
                     textDocumentProxy.deleteBackward()
                     textDocumentProxy.insertText(makeWord(chojung[0], doubleJung, invalidKey))
                     buffer.removeLast()
                     buffer.append(doubleJung)
-                } else { //MARK: 아닌 경우
+                } else {
                     buffer.append(key)
                     delBuffer += buffer
                     buffer.removeAll()
@@ -267,7 +264,6 @@ private extension KeyboardViewController {
         case 3:
             let chojungjong = Array(buffer.suffix(3))
             let doubleJong = Hangul.makeJongDoublePhoneme(chojungjong[2], key)
-            print(doubleJong)
             if doubleJong.keyword != "" {
                 textDocumentProxy.deleteBackward()
                 textDocumentProxy.insertText(makeWord(chojungjong[0], chojungjong[1], doubleJong))

--- a/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
+++ b/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
@@ -275,10 +275,6 @@ extension KeyboardViewController {
                 if buffer.count >= 3 {
                     guard let lastKey = buffer.last else { return }
                     buffer.removeLast()
-                    if !Hangul.doublePhonemes.contains(lastKey.keyword) {
-                        state = 2
-                        return
-                    }
                     let lastKeys = Hangul.breakJongDoublePhoneme(lastKey)
                     buffer.append(lastKeys.0)
                     let lastThreeKeys = Array(buffer.suffix(3))
@@ -327,9 +323,7 @@ extension KeyboardViewController {
                 if deleteKeys.0.keyword == "" {
                     if buffer.count == 3 {
                         let lastThreeKeys = Array(buffer.suffix(3))
-                        print(lastThreeKeys)
                         let word = makeWord(lastThreeKeys[0], lastThreeKeys[1], Hangul.makeJongDoublePhoneme(lastThreeKeys[2], invalidKey))
-                        print(word)
                         if word != "" {
                             textDocumentProxy.deleteBackward()
                             textDocumentProxy.insertText(word)

--- a/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
+++ b/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
@@ -10,7 +10,8 @@ import UIKit
 class KeyboardViewController: UIInputViewController {
     
     var buffer = [KeyModel]()
-    var inputState: Int = 0
+    var delBuffer = [KeyModel]()
+    var state: Int = 0
     
     private var keyboardView: KeyboardView!
     private var frequentlyUsedPhrasesView: FrequentlyUsedPhrasesView!
@@ -70,19 +71,19 @@ extension KeyboardViewController: KeyboardViewDelegate {
         case 102:
             textDocumentProxy.deleteBackward()
             buffer.removeAll()
-            inputState = 0
+            state = 0
         case 103:
             textDocumentProxy.insertText(key.keyword)
             buffer.removeAll()
-            inputState = 0
+            state = 0
         case 104:
             textDocumentProxy.insertText(" ")
             buffer.removeAll()
-            inputState = 0
+            state = 0
         case 105:
             textDocumentProxy.insertText("\n")
             buffer.removeAll()
-            inputState = 0
+            state = 0
         default:
             handleKeyInput(key)
             if shiftKeyState == .constant {
@@ -168,7 +169,7 @@ private extension KeyboardViewController {
             return
         }
         
-        switch inputState {
+        switch state {
         case 0:
             if Hangul.jungs.contains(key.keyword) {
                 guard let firstJung = buffer.last else {
@@ -190,7 +191,7 @@ private extension KeyboardViewController {
             } else {
                 textDocumentProxy.insertText(key.keyword)
                 buffer.append(key)
-                inputState = 1
+                state = 1
             }
         case 1:
             if Hangul.jungs.contains(key.keyword) {
@@ -205,7 +206,7 @@ private extension KeyboardViewController {
                 }
                 textDocumentProxy.insertText(makeWord(cho.uniValue, key.uniValue, 0))
                 buffer.append(key)
-                inputState = 2
+                state = 2
             } else {
                 textDocumentProxy.insertText(key.keyword)
                 buffer.removeAll()
@@ -223,13 +224,13 @@ private extension KeyboardViewController {
                 } else {
                     buffer.removeAll()
                     textDocumentProxy.insertText(key.keyword)
-                    inputState = 0
+                    state = 0
                 }
             } else {
                 textDocumentProxy.deleteBackward()
                 textDocumentProxy.insertText(makeWord(chojung[0].uniValue, chojung[1].uniValue, Hangul.makeJongDoublePhoneme(key, KeyModel(keyword: "", uniValue: 0)).uniValue))
                 buffer.append(key)
-                inputState = 3
+                state = 3
             }
         case 3:
             let chojungjong = Array(buffer.suffix(3))
@@ -238,11 +239,11 @@ private extension KeyboardViewController {
                 textDocumentProxy.deleteBackward()
                 textDocumentProxy.insertText(makeWord(chojungjong[0].uniValue, chojungjong[1].uniValue, doubleJong.uniValue))
                 buffer.append(key)
-                inputState = 1
+                state = 1
             }
             else if Hangul.chos.contains(key.keyword) {
                 buffer.removeAll()
-                inputState = 1
+                state = 1
                 textDocumentProxy.insertText(key.keyword)
                 buffer.append(key)
             } else if Hangul.jungs.contains(key.keyword) {
@@ -251,7 +252,7 @@ private extension KeyboardViewController {
                 textDocumentProxy.deleteBackward()
                 textDocumentProxy.insertText(makeWord(chojungjong[0].uniValue, chojungjong[1].uniValue, 0))
                 textDocumentProxy.insertText(makeWord(cho.uniValue, key.uniValue, 0))
-                inputState = 2
+                state = 2
                 buffer.append(key)
             }
             

--- a/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
+++ b/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
@@ -330,6 +330,7 @@ extension KeyboardViewController {
             if !buffer.isEmpty {
                 if buffer.count >= 3 { // 앉 과 같은 상황
                     guard let lastKey = buffer.last else { return }
+                    print(lastKey)
                     buffer.removeLast()
                     if !Hangul.doublePhonemes.contains(lastKey.keyword) { //이중 종성이 아닌 경우
                         state = 2
@@ -390,6 +391,15 @@ extension KeyboardViewController {
                     
                 }
                 
+            }
+            
+        case 3:
+            textDocumentProxy.deleteBackward()
+            if !buffer.isEmpty {
+                buffer.removeLast()
+                let lastTwoKeys = Array(buffer.suffix(2))
+                textDocumentProxy.insertText(makeWord(lastTwoKeys[0], lastTwoKeys[1], invalidKey))
+                state = 2
             }
 
         default:

--- a/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
+++ b/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
@@ -111,61 +111,6 @@ extension KeyboardViewController: KeyboardViewDelegate {
     }
 }
 
-extension KeyboardViewController: ToolbarViewDelegate {
-    func setFrequentlyUsedPhrasesView(_ isSelected: Bool) {
-        if isSelected {
-            setUpFrequentlyUsedPhrasesViewLayout()
-            frequentlyUsedPhrasesView.delegate = self
-        } else {
-            frequentlyUsedPhrasesView.removeFromSuperview()
-        }
-    }
-}
-
-extension KeyboardViewController: FrequentlyUsedPhrasesViewDelegate {
-    func setFrequentlyUsedPhrases(_ text: String) {
-        let proxy = textDocumentProxy as UITextDocumentProxy
-        proxy.insertText(text)
-    }
-}
-
-private extension KeyboardViewController {
-    func setUpToolBarLayout() {
-        toolbar.delegate = self
-        view.addSubview(toolbar)
-        toolbar.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            toolbar.topAnchor.constraint(equalTo: view.topAnchor),
-            toolbar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            toolbar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            toolbar.heightAnchor.constraint(equalToConstant: Size.toolbarHeight)
-        ])
-    }
-    
-    func setUpKeyboardViewLayout() {
-        view.addSubview(keyboardView)
-        keyboardView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            keyboardView.topAnchor.constraint(equalTo: toolbar.bottomAnchor),
-            keyboardView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            keyboardView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            keyboardView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        ])
-    }
-    
-    func setUpFrequentlyUsedPhrasesViewLayout() {
-        frequentlyUsedPhrasesView = FrequentlyUsedPhrasesView()
-        view.addSubview(frequentlyUsedPhrasesView)
-        frequentlyUsedPhrasesView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            frequentlyUsedPhrasesView.topAnchor.constraint(equalTo: toolbar.bottomAnchor),
-            frequentlyUsedPhrasesView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            frequentlyUsedPhrasesView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            frequentlyUsedPhrasesView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        ])
-    }
-}
-
 private extension KeyboardViewController {
     
     func makeWord(_ cho: KeyModel, _ jung: KeyModel, _ jong: KeyModel) -> String {
@@ -404,3 +349,60 @@ extension KeyboardViewController {
         }
     }
 }
+
+
+extension KeyboardViewController: ToolbarViewDelegate {
+    func setFrequentlyUsedPhrasesView(_ isSelected: Bool) {
+        if isSelected {
+            setUpFrequentlyUsedPhrasesViewLayout()
+            frequentlyUsedPhrasesView.delegate = self
+        } else {
+            frequentlyUsedPhrasesView.removeFromSuperview()
+        }
+    }
+}
+
+extension KeyboardViewController: FrequentlyUsedPhrasesViewDelegate {
+    func setFrequentlyUsedPhrases(_ text: String) {
+        let proxy = textDocumentProxy as UITextDocumentProxy
+        proxy.insertText(text)
+    }
+}
+
+private extension KeyboardViewController {
+    func setUpToolBarLayout() {
+        toolbar.delegate = self
+        view.addSubview(toolbar)
+        toolbar.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            toolbar.topAnchor.constraint(equalTo: view.topAnchor),
+            toolbar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            toolbar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            toolbar.heightAnchor.constraint(equalToConstant: Size.toolbarHeight)
+        ])
+    }
+    
+    func setUpKeyboardViewLayout() {
+        view.addSubview(keyboardView)
+        keyboardView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            keyboardView.topAnchor.constraint(equalTo: toolbar.bottomAnchor),
+            keyboardView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            keyboardView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            keyboardView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+    
+    func setUpFrequentlyUsedPhrasesViewLayout() {
+        frequentlyUsedPhrasesView = FrequentlyUsedPhrasesView()
+        view.addSubview(frequentlyUsedPhrasesView)
+        frequentlyUsedPhrasesView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            frequentlyUsedPhrasesView.topAnchor.constraint(equalTo: toolbar.bottomAnchor),
+            frequentlyUsedPhrasesView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            frequentlyUsedPhrasesView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            frequentlyUsedPhrasesView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+}
+

--- a/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
+++ b/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
@@ -170,8 +170,6 @@ private extension KeyboardViewController {
                     let chojungjong = Array(buffer.suffix(3))
                     buffer.removeLast()
                     buffer.append(lastKeys.0)
-                    delBuffer += buffer
-                    buffer.removeAll()
                     textDocumentProxy.insertText(makeWord(chojungjong[0], chojungjong[1], lastKeys.0))
                     textDocumentProxy.insertText(makeWord(Hangul.breakJongDoublePhoneme(lastKeys.1).0, key, invalidKey))
                     buffer.append(lastKeys.1)
@@ -327,8 +325,34 @@ extension KeyboardViewController {
                 guard let lastKey = buffer.last else { return }
                 let deleteKeys = Hangul.breakJungDoublePhoneme(deleteKey)
                 if deleteKeys.0.keyword == "" {
-                    textDocumentProxy.insertText(lastKey.keyword)
-                    state = 1
+                    if buffer.count == 3 {
+                        let lastThreeKeys = Array(buffer.suffix(3))
+                        print(lastThreeKeys)
+                        let word = makeWord(lastThreeKeys[0], lastThreeKeys[1], Hangul.makeJongDoublePhoneme(lastThreeKeys[2], invalidKey))
+                        print(word)
+                        if word != "" {
+                            textDocumentProxy.deleteBackward()
+                            textDocumentProxy.insertText(word)
+                            state = 3
+                        }
+                    }
+                    else if buffer.count >= 4 {
+                        let lastFourKeys = Array(buffer.suffix(4))
+                        let doubleJong = Hangul.makeJongDoublePhoneme(lastFourKeys[2], lastFourKeys[3])
+                        let word = makeWord(lastFourKeys[0], lastFourKeys[1], doubleJong)
+                            buffer.removeLast(2)
+                            buffer.append(doubleJong)
+                            if word != "" {
+                                textDocumentProxy.deleteBackward()
+                                textDocumentProxy.insertText(word)
+                                state = 1
+                            }
+                        
+                    }
+                    else {
+                        textDocumentProxy.insertText(lastKey.keyword)
+                        state = 1
+                    }
                 } else {
                     textDocumentProxy.insertText(makeWord(lastKey, deleteKeys.0, invalidKey))
                     buffer.append(deleteKeys.0)
@@ -343,7 +367,7 @@ extension KeyboardViewController {
                 textDocumentProxy.insertText(makeWord(lastTwoKeys[0], lastTwoKeys[1], invalidKey))
                 state = 2
             }
-
+            
         default:
             break
         }

--- a/CustomKeyboard/KoreanKeyboard/Literal/Hangul.swift
+++ b/CustomKeyboard/KoreanKeyboard/Literal/Hangul.swift
@@ -125,21 +125,21 @@ enum Hangul {
     static func breakJongDoublePhoneme(_ jong: KeyModel) -> (KeyModel, KeyModel) {
         switch jong.keyword {
         case "ㄱ":
-            return (KeyModel(keyword: "ㄱ", uniValue: 1), KeyModel(keyword: "", uniValue: 0))
+            return (KeyModel(keyword: "ㄱ", uniValue: 0), KeyModel(keyword: "", uniValue: 0))
         case "ㄲ":
-            return (KeyModel(keyword: "ㄲ", uniValue: 2), KeyModel(keyword: "", uniValue: 0))
+            return (KeyModel(keyword: "ㄲ", uniValue: 1), KeyModel(keyword: "", uniValue: 0))
         case "ㄳ":
             return (KeyModel(keyword: "ㄱ", uniValue: 1), KeyModel(keyword: "ㅅ", uniValue: 9))
         case "ㄴ":
-            return (KeyModel(keyword: "ㄴ", uniValue: 4), KeyModel(keyword: "", uniValue: 0))
+            return (KeyModel(keyword: "ㄴ", uniValue: 2), KeyModel(keyword: "", uniValue: 0))
         case "ㄵ":
             return (KeyModel(keyword: "ㄴ", uniValue: 4), KeyModel(keyword: "ㅈ", uniValue: 12))
         case "ㄶ":
             return (KeyModel(keyword: "ㄴ", uniValue: 4), KeyModel(keyword: "ㅎ", uniValue: 18))
         case "ㄷ":
-            return (KeyModel(keyword: "ㄷ", uniValue: 7), KeyModel(keyword: "", uniValue: 0))
+            return (KeyModel(keyword: "ㄷ", uniValue: 3), KeyModel(keyword: "", uniValue: 0))
         case "ㄹ":
-            return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "", uniValue: 0))
+            return (KeyModel(keyword: "ㄹ", uniValue: 5), KeyModel(keyword: "", uniValue: 0))
         case "ㄺ":
             return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "ㄱ", uniValue: 0))
         case "ㄻ":
@@ -155,29 +155,29 @@ enum Hangul {
         case "ㅀ":
             return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "ㅎ", uniValue: 18))
         case "ㅁ":
-            return (KeyModel(keyword: "ㅁ", uniValue: 16), KeyModel(keyword: "", uniValue: 0))
+            return (KeyModel(keyword: "ㅁ", uniValue: 6), KeyModel(keyword: "", uniValue: 0))
         case "ㅂ":
-            return (KeyModel(keyword: "ㅂ", uniValue: 17), KeyModel(keyword: "", uniValue: 0))
+            return (KeyModel(keyword: "ㅂ", uniValue: 7), KeyModel(keyword: "", uniValue: 0))
         case "ㅄ":
             return (KeyModel(keyword: "ㅂ", uniValue: 17), KeyModel(keyword: "ㅅ", uniValue: 9))
         case "ㅅ":
-            return (KeyModel(keyword: "ㅅ", uniValue: 19), KeyModel(keyword: "", uniValue: 0))
+            return (KeyModel(keyword: "ㅅ", uniValue: 9), KeyModel(keyword: "", uniValue: 0))
         case "ㅆ":
             return (KeyModel(keyword: "ㅆ", uniValue: 20), KeyModel(keyword: "", uniValue: 0))
         case "ㅇ":
-            return (KeyModel(keyword: "ㅇ", uniValue: 21), KeyModel(keyword: "", uniValue: 0))
+            return (KeyModel(keyword: "ㅇ", uniValue: 11), KeyModel(keyword: "", uniValue: 0))
         case "ㅈ":
-            return (KeyModel(keyword: "ㅈ", uniValue: 22), KeyModel(keyword: "", uniValue: 0))
+            return (KeyModel(keyword: "ㅈ", uniValue: 12), KeyModel(keyword: "", uniValue: 0))
         case "ㅊ":
-            return (KeyModel(keyword: "ㅊ", uniValue: 23), KeyModel(keyword: "", uniValue: 0))
+            return (KeyModel(keyword: "ㅊ", uniValue: 14), KeyModel(keyword: "", uniValue: 0))
         case "ㅋ":
-            return (KeyModel(keyword: "ㅋ", uniValue: 24), KeyModel(keyword: "", uniValue: 0))
+            return (KeyModel(keyword: "ㅋ", uniValue: 15), KeyModel(keyword: "", uniValue: 0))
         case "ㅌ":
-            return (KeyModel(keyword: "ㅌ", uniValue: 25), KeyModel(keyword: "", uniValue: 0))
+            return (KeyModel(keyword: "ㅌ", uniValue: 16), KeyModel(keyword: "", uniValue: 0))
         case "ㅍ":
-            return (KeyModel(keyword: "ㅍ", uniValue: 26), KeyModel(keyword: "", uniValue: 0))
+            return (KeyModel(keyword: "ㅍ", uniValue: 17), KeyModel(keyword: "", uniValue: 0))
         case "ㅎ":
-            return (KeyModel(keyword: "ㅎ", uniValue: 27), KeyModel(keyword: "", uniValue: 0))
+            return (KeyModel(keyword: "ㅎ", uniValue: 18), KeyModel(keyword: "", uniValue: 0))
         default:
             return (KeyModel(keyword: "", uniValue: 0), KeyModel(keyword: "", uniValue: 0))
         }

--- a/CustomKeyboard/KoreanKeyboard/Literal/Hangul.swift
+++ b/CustomKeyboard/KoreanKeyboard/Literal/Hangul.swift
@@ -12,7 +12,7 @@ enum Hangul {
     static let chos: Set<String> = ["ㄱ", "ㄴ", "ㄷ", "ㄹ", "ㅁ", "ㅂ", "ㅅ", "ㅇ", "ㅈ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ", "ㄲ", "ㅃ", "ㅉ", "ㄸ", "ㅆ"]
     static let jungs: Set<String> = ["ㅏ", "ㅑ", "ㅓ", "ㅕ", "ㅗ", "ㅛ", "ㅜ", "ㅠ", "ㅡ", "ㅣ", "ㅐ", "ㅒ", "ㅔ", "ㅖ", "ㅘ", "ㅙ", "ㅚ", "ㅝ", "ㅞ", "ㅟ", "ㅢ"]
     static let jongs: Set<String> = ["", "ㄱ", "ㄲ", "ㄳ", "ㄴ", "ㄵ", "ㄶ", "ㄷ", "ㄹ", "ㄺ", "ㄻ", "ㄼ", "ㄽ", "ㄾ", "ㄿ", "ㅀ", "ㅁ", "ㅂ", "ㅄ", "ㅅ", "ㅆ", "ㅇ", "ㅈ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ"]
-    static let lastJongs: Set<String> = ["ㅅ", "ㅈ", "ㅎ", "ㄱ", "ㅁ", "ㅂ", "ㅌ", "ㅍ"]
+    static let doublePhonemes: Set<String> = ["ㄳ", "ㅘ", "ㅙ", "ㅚ", "ㅝ", "ㅞ", "ㅟ", "ㅢ", "ㄵ", "ㄶ", "ㄺ", "ㄻ", "ㄼ", "ㄽ", "ㄾ", "ㄿ", "ㅀ"]
     
     static func makeJungDoublePhoneme(_ firstKey: KeyModel, _ lastKey: KeyModel) -> KeyModel {
         let doublePhoneme: [String] = [firstKey.keyword, lastKey.keyword]
@@ -36,6 +36,28 @@ enum Hangul {
             return KeyModel(keyword: "", uniValue: 0)
         }
     }
+    
+    static func breakJungDoublePhoneme(_ jung: KeyModel) -> (KeyModel, KeyModel) {
+        switch jung.keyword {
+        case "ㅘ":
+            return (KeyModel(keyword: "ㅗ", uniValue: 8), KeyModel(keyword: "ㅏ", uniValue: 0))
+        case "ㅙ":
+            return (KeyModel(keyword: "ㅗ", uniValue: 8), KeyModel(keyword: "ㅐ", uniValue: 1))
+        case "ㅚ":
+            return (KeyModel(keyword: "ㅗ", uniValue: 8), KeyModel(keyword: "ㅣ", uniValue: 20))
+        case "ㅝ":
+            return (KeyModel(keyword: "ㅜ", uniValue: 13), KeyModel(keyword: "ㅓ", uniValue: 4))
+        case "ㅞ":
+            return (KeyModel(keyword: "ㅜ", uniValue: 13), KeyModel(keyword: "ㅔ", uniValue: 5))
+        case "ㅟ":
+            return (KeyModel(keyword: "ㅜ", uniValue: 13), KeyModel(keyword: "ㅣ", uniValue: 20))
+        case "ㅢ":
+            return (KeyModel(keyword: "ㅡ", uniValue: 18), KeyModel(keyword: "ㅣ", uniValue: 20))
+        default:
+            return (KeyModel(keyword: "", uniValue: 0), KeyModel(keyword: "", uniValue: 0))
+        }
+    }
+
     
     static func makeJongDoublePhoneme(_ firstKey: KeyModel, _ lastKey: KeyModel) -> KeyModel {
         let doublePhoneme: [String] = [firstKey.keyword, lastKey.keyword]

--- a/CustomKeyboard/KoreanKeyboard/Literal/Hangul.swift
+++ b/CustomKeyboard/KoreanKeyboard/Literal/Hangul.swift
@@ -12,7 +12,7 @@ enum Hangul {
     static let chos: Set<String> = ["ㄱ", "ㄴ", "ㄷ", "ㄹ", "ㅁ", "ㅂ", "ㅅ", "ㅇ", "ㅈ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ", "ㄲ", "ㅃ", "ㅉ", "ㄸ", "ㅆ"]
     static let jungs: Set<String> = ["ㅏ", "ㅑ", "ㅓ", "ㅕ", "ㅗ", "ㅛ", "ㅜ", "ㅠ", "ㅡ", "ㅣ", "ㅐ", "ㅒ", "ㅔ", "ㅖ", "ㅘ", "ㅙ", "ㅚ", "ㅝ", "ㅞ", "ㅟ", "ㅢ"]
     static let jongs: Set<String> = ["", "ㄱ", "ㄲ", "ㄳ", "ㄴ", "ㄵ", "ㄶ", "ㄷ", "ㄹ", "ㄺ", "ㄻ", "ㄼ", "ㄽ", "ㄾ", "ㄿ", "ㅀ", "ㅁ", "ㅂ", "ㅄ", "ㅅ", "ㅆ", "ㅇ", "ㅈ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ"]
-    static let doublePhonemes: Set<String> = ["ㄳ", "ㅘ", "ㅙ", "ㅚ", "ㅝ", "ㅞ", "ㅟ", "ㅢ", "ㄵ", "ㄶ", "ㄺ", "ㄻ", "ㄼ", "ㄽ", "ㄾ", "ㄿ", "ㅀ"]
+    static let doublePhonemes: Set<String> = ["ㄳ", "ㅘ", "ㅙ", "ㅚ", "ㅝ", "ㅞ", "ㅟ", "ㅢ", "ㄵ", "ㄶ", "ㄺ", "ㄻ", "ㄼ", "ㄽ", "ㄾ", "ㄿ", "ㅀ", "ㅄ"]
     
     static func makeJungDoublePhoneme(_ firstKey: KeyModel, _ lastKey: KeyModel) -> KeyModel {
         let doublePhoneme: [String] = [firstKey.keyword, lastKey.keyword]

--- a/CustomKeyboard/KoreanKeyboard/Literal/Hangul.swift
+++ b/CustomKeyboard/KoreanKeyboard/Literal/Hangul.swift
@@ -107,37 +107,37 @@ enum Hangul {
         case "ㄲ":
             return (KeyModel(keyword: "ㄲ", uniValue: 2), KeyModel(keyword: "", uniValue: 0))
         case "ㄳ":
-            return (KeyModel(keyword: "ㄱ", uniValue: 1), KeyModel(keyword: "ㅅ", uniValue: 19))
+            return (KeyModel(keyword: "ㄱ", uniValue: 1), KeyModel(keyword: "ㅅ", uniValue: 9))
         case "ㄴ":
             return (KeyModel(keyword: "ㄴ", uniValue: 4), KeyModel(keyword: "", uniValue: 0))
         case "ㄵ":
-            return (KeyModel(keyword: "ㄴ", uniValue: 4), KeyModel(keyword: "ㅈ", uniValue: 22))
+            return (KeyModel(keyword: "ㄴ", uniValue: 4), KeyModel(keyword: "ㅈ", uniValue: 12))
         case "ㄶ":
-            return (KeyModel(keyword: "ㄴ", uniValue: 4), KeyModel(keyword: "ㅎ", uniValue: 27))
+            return (KeyModel(keyword: "ㄴ", uniValue: 4), KeyModel(keyword: "ㅎ", uniValue: 18))
         case "ㄷ":
             return (KeyModel(keyword: "ㄷ", uniValue: 7), KeyModel(keyword: "", uniValue: 0))
         case "ㄹ":
             return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "", uniValue: 0))
         case "ㄺ":
-            return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "ㄱ", uniValue: 1))
+            return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "ㄱ", uniValue: 0))
         case "ㄻ":
-            return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "ㅁ", uniValue: 16))
+            return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "ㅁ", uniValue: 6))
         case "ㄼ":
-            return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "ㅂ", uniValue: 17))
+            return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "ㅂ", uniValue: 7))
         case "ㄽ":
-            return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "ㅅ", uniValue: 19))
+            return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "ㅅ", uniValue: 9))
         case "ㄾ":
-            return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "ㅌ", uniValue: 25))
+            return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "ㅌ", uniValue: 16))
         case "ㄿ":
-            return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "ㅍ", uniValue: 26))
+            return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "ㅍ", uniValue: 17))
         case "ㅀ":
-            return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "ㅎ", uniValue: 27))
+            return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "ㅎ", uniValue: 18))
         case "ㅁ":
             return (KeyModel(keyword: "ㅁ", uniValue: 16), KeyModel(keyword: "", uniValue: 0))
         case "ㅂ":
             return (KeyModel(keyword: "ㅂ", uniValue: 17), KeyModel(keyword: "", uniValue: 0))
         case "ㅄ":
-            return (KeyModel(keyword: "ㅂ", uniValue: 17), KeyModel(keyword: "ㅅ", uniValue: 19))
+            return (KeyModel(keyword: "ㅂ", uniValue: 17), KeyModel(keyword: "ㅅ", uniValue: 9))
         case "ㅅ":
             return (KeyModel(keyword: "ㅅ", uniValue: 19), KeyModel(keyword: "", uniValue: 0))
         case "ㅆ":

--- a/CustomKeyboard/KoreanKeyboard/Literal/Hangul.swift
+++ b/CustomKeyboard/KoreanKeyboard/Literal/Hangul.swift
@@ -10,8 +10,8 @@ import Foundation
 enum Hangul {
     
     static let chos: Set<String> = ["ㄱ", "ㄴ", "ㄷ", "ㄹ", "ㅁ", "ㅂ", "ㅅ", "ㅇ", "ㅈ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ", "ㄲ", "ㅃ", "ㅉ", "ㄸ", "ㅆ"]
-    static let jungs: Set<String> = ["ㅏ", "ㅑ", "ㅓ", "ㅕ", "ㅗ", "ㅛ", "ㅜ", "ㅠ", "ㅡ", "ㅣ", "ㅐ", "ㅒ", "ㅔ", "ㅖ"]
-    static let jongs: Set<String> = [" ", "ㄱ", "ㄲ", "ㄳ", "ㄴ", "ㄵ", "ㄶ", "ㄷ", "ㄹ", "ㄺ", "ㄻ", "ㄼ", "ㄽ", "ㄾ", "ㄿ", "ㅀ", "ㅁ", "ㅂ", "ㅄ", "ㅅ", "ㅆ", "ㅇ", "ㅈ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ"]
+    static let jungs: Set<String> = ["ㅏ", "ㅑ", "ㅓ", "ㅕ", "ㅗ", "ㅛ", "ㅜ", "ㅠ", "ㅡ", "ㅣ", "ㅐ", "ㅒ", "ㅔ", "ㅖ", "ㅘ", "ㅙ", "ㅚ", "ㅝ", "ㅞ", "ㅟ", "ㅢ"]
+    static let jongs: Set<String> = ["", "ㄱ", "ㄲ", "ㄳ", "ㄴ", "ㄵ", "ㄶ", "ㄷ", "ㄹ", "ㄺ", "ㄻ", "ㄼ", "ㄽ", "ㄾ", "ㄿ", "ㅀ", "ㅁ", "ㅂ", "ㅄ", "ㅅ", "ㅆ", "ㅇ", "ㅈ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ"]
     static let lastJongs: Set<String> = ["ㅅ", "ㅈ", "ㅎ", "ㄱ", "ㅁ", "ㅂ", "ㅌ", "ㅍ"]
     
     static func makeJungDoublePhoneme(_ firstKey: KeyModel, _ lastKey: KeyModel) -> KeyModel {
@@ -97,6 +97,67 @@ enum Hangul {
             return KeyModel(keyword: "ㅎ", uniValue: 27)
         default:
             return KeyModel(keyword: "", uniValue: 0)
+        }
+    }
+    
+    static func breakJongDoublePhoneme(_ jong: KeyModel) -> (KeyModel, KeyModel) {
+        switch jong.keyword {
+        case "ㄱ":
+            return (KeyModel(keyword: "ㄱ", uniValue: 1), KeyModel(keyword: "", uniValue: 0))
+        case "ㄲ":
+            return (KeyModel(keyword: "ㄲ", uniValue: 2), KeyModel(keyword: "", uniValue: 0))
+        case "ㄳ":
+            return (KeyModel(keyword: "ㄱ", uniValue: 1), KeyModel(keyword: "ㅅ", uniValue: 19))
+        case "ㄴ":
+            return (KeyModel(keyword: "ㄴ", uniValue: 4), KeyModel(keyword: "", uniValue: 0))
+        case "ㄵ":
+            return (KeyModel(keyword: "ㄴ", uniValue: 4), KeyModel(keyword: "ㅈ", uniValue: 22))
+        case "ㄶ":
+            return (KeyModel(keyword: "ㄴ", uniValue: 4), KeyModel(keyword: "ㅎ", uniValue: 27))
+        case "ㄷ":
+            return (KeyModel(keyword: "ㄷ", uniValue: 7), KeyModel(keyword: "", uniValue: 0))
+        case "ㄹ":
+            return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "", uniValue: 0))
+        case "ㄺ":
+            return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "ㄱ", uniValue: 1))
+        case "ㄻ":
+            return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "ㅁ", uniValue: 16))
+        case "ㄼ":
+            return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "ㅂ", uniValue: 17))
+        case "ㄽ":
+            return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "ㅅ", uniValue: 19))
+        case "ㄾ":
+            return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "ㅌ", uniValue: 25))
+        case "ㄿ":
+            return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "ㅍ", uniValue: 26))
+        case "ㅀ":
+            return (KeyModel(keyword: "ㄹ", uniValue: 8), KeyModel(keyword: "ㅎ", uniValue: 27))
+        case "ㅁ":
+            return (KeyModel(keyword: "ㅁ", uniValue: 16), KeyModel(keyword: "", uniValue: 0))
+        case "ㅂ":
+            return (KeyModel(keyword: "ㅂ", uniValue: 17), KeyModel(keyword: "", uniValue: 0))
+        case "ㅄ":
+            return (KeyModel(keyword: "ㅂ", uniValue: 17), KeyModel(keyword: "ㅅ", uniValue: 19))
+        case "ㅅ":
+            return (KeyModel(keyword: "ㅅ", uniValue: 19), KeyModel(keyword: "", uniValue: 0))
+        case "ㅆ":
+            return (KeyModel(keyword: "ㅆ", uniValue: 20), KeyModel(keyword: "", uniValue: 0))
+        case "ㅇ":
+            return (KeyModel(keyword: "ㅇ", uniValue: 21), KeyModel(keyword: "", uniValue: 0))
+        case "ㅈ":
+            return (KeyModel(keyword: "ㅈ", uniValue: 22), KeyModel(keyword: "", uniValue: 0))
+        case "ㅊ":
+            return (KeyModel(keyword: "ㅊ", uniValue: 23), KeyModel(keyword: "", uniValue: 0))
+        case "ㅋ":
+            return (KeyModel(keyword: "ㅋ", uniValue: 24), KeyModel(keyword: "", uniValue: 0))
+        case "ㅌ":
+            return (KeyModel(keyword: "ㅌ", uniValue: 25), KeyModel(keyword: "", uniValue: 0))
+        case "ㅍ":
+            return (KeyModel(keyword: "ㅍ", uniValue: 26), KeyModel(keyword: "", uniValue: 0))
+        case "ㅎ":
+            return (KeyModel(keyword: "ㅎ", uniValue: 27), KeyModel(keyword: "", uniValue: 0))
+        default:
+            return (KeyModel(keyword: "", uniValue: 0), KeyModel(keyword: "", uniValue: 0))
         }
     }
 }


### PR DESCRIPTION
# 입력 텍스트 삭제 시 음소 단위로 삭제되는 기능을 구현하였습니다.
close #10 
구현 사항
- 변수명 수정
- 이중 중성, 종성 -> 중성, 종성 으로 분리하는 메소드 구현
- `case` 별로 삭제하는 로직 구현
- `buffer`, `state` 초기화 함수 구현
- shift키 초기화 함수 구현

## 설계 화면
<img width="1000" alt="image" src="https://github.com/TaekH/CustomKeyboard/assets/103012087/89c753a1-21bf-4d23-917a-e65f22d82fe4">

## 구현 화면

<img src = "https://github.com/TaekH/CustomKeyboard/assets/103012087/34ddbbeb-a7ec-4729-a425-27c97b22bd19" width = 300>


## 변수명 수정
`inputState` -> `state`로 수정하였습니다.
`inputState`변수를 `input`이 아닌 `delete` 상황에서도 사용하기 때문에 `state`가 더 맞는 변수명이라고 판단하였습니다.

## `breakDoubleJung(Jong)()` 구현
이중 종성과 중성을 각각 분리해서 두개의 종성, 중성으로 반환하는 메소드입니다.

```swift
    static func breakJongDoublePhoneme(_ jong: KeyModel) -> (KeyModel, KeyModel) {
        switch jong.keyword {
        case "ㄱ":
            return (KeyModel(keyword: "ㄱ", uniValue: 0), KeyModel(keyword: "", uniValue: 0))
        case "ㄲ":
            return (KeyModel(keyword: "ㄲ", uniValue: 1), KeyModel(keyword: "", uniValue: 0))
. . .
```

#11 에서 구현한 `makeJongDoublePhoneme()` 과 반대의 함수입니다.
차이점은 반환되는 `uniValue` 값에 있습니다.
"값" 의 경우 "갑사" 와 같은 방식으로 출력하기 위한 로직이므로 "ㅅ"의 경우 `uniValue`가 종성에서 초성의 `uniValue`를 출력해야합니다.
또한 "갑"의 경우에도 중음이 붙을 경우에 "가보" 와 같은 "ㅂ"이 초성으로 위치하게 되면서 "ㅂ"을 따로 한번 더 `breakDoubleJong()`을 거치고 이때 `uniValue`가 초성의 `uniValue`로 변경되서 나오게 됩니다.

즉 이중 종(중)성을 나눠주기도 하지만 반대로 초성의 `uniValue`를 갖고 나오게 하는 역할을 수행하는 메소드입니다.

## case별로 삭제하는 로직 구현

#11 에서 `buffer`를 사용하고 때에 따라 인덱싱을 위해 `buffer`를 비우기 때문에 `TextField`에는 있는 단어가 `buffer`에 존재하지 않는 경우가 있습니다.
이를 위해서 따로 `delBuffer`를 구현하여 `buffer`가 새로운 입력을 받기위해서 초기화될 때 `delBuffer`에 저장 후 초기화하도록 하여 입력된 데이터의 누락이 없도록 합니다.

### case 0:
입력이 실행되지 않았거나 중성만 입력된 상태 ( 이중 중성도 가능 )

입력된 텍스트를 삭제합니다.

- 중성 하나가 입력된 경우 ("ㅏ")
    - `buffer.count == 1` 이므로 단순히 `buffer`를 삭제합니다.

- 이중 중성인 경우 ("ㅢ")
  - `delBuffer`에 존재합니다.
  - 입력된 텍스트 만을 지웁니다. 

- 앞에 다른 단어들이 있는 경우 ("어ㅏ")
  - 중성이 겹치는 경우밖에 없으므로 맨 뒤의 두 단어 조합을 검토합니다.
  - 검토 결과 "어"와 같은 단어가 만들어진다면 `state=2`
  - 만들어지지 않는다면 ("ㅏㅏㅏ") 같은 상태이므로 state는 그대로 0 입니다.

### case 1:
초성만 입력되거나 "값"과 같은 마지막이 이중 종성으로 끝나는 경우

입력된 텍스트를 삭제합니다.

- 초성 하나가 입력된 경우 ("ㅇ")
  - 단순히 `buffer`에서 삭제합니다.
  - `state = 0`

- `buffer`에 ("앉")과 같은 이중 종성으로 끝난 단어가 있는 경우
  - `buffer`의 마지막 `key`를 분리합니다.
  - "ㅈ"은 삭제하고 "안"을 조합합니다.
  - `state = 3`

-  "ㅏㅏㅏㅇ", "ㅇㅇㅇㅇ" 과 같이 초성 또는 중성으로만 이루어진 경우
  - 조합이 되는지 테스트 한 후에 조합이 되지 않으면 반환합니다.
  - #11 에서 "ㅏ", "ㅇ" 등의 조합이 되지 않는 초성, 중성이 반복되는 경우 `delBuffer`에 쌓이고 `buffer`는 초기화되므로 "ㅇ"과 같은 초성의 경우에는 다시 `buffer`로 삽입합니다.. ("ㅇㅇ" -> "ㅇ" -> "ㅇ"+"ㅏ" 와 같은 경우 )

### case 2:
마지막으로 중성또는 이중 중성이 입력된 경우

입력된 텍스트를 삭제합니다.

- 초성과 중성만 합쳐진 경우 ("아")
  - `buffer`에서 지워주고 남은 "ㅇ"을 출력합니다.
  - `state = 1`

  - 이중 중성이 입력된 경우 ("왜")
  - 중성을 분리합니다. ("ㅗ", "ㅐ")
  - 앞의 중성과 그 앞의 초성을 단어로 합친 후에 다시 출력합니다. ("오")
  - `state = 1`

- 종성 단어에서 중성이 붙었던 경우 ("가사")
  - `buffer.count == 3` 으로 확인합니다. (새 단어가 만들어지게 되면 `buffer`가 비워지므로 "가사"  남게됩니다. )
  - 단어를 조합하여 "갓"을 다시 출력합니다.
  - `state = 3`

- 이중 종성 단어에서 중성이 붙었던 경우 ("갑사")
  - `buffer.count >= 4`로 확인합니다.
  - "ㅂ","ㅅ"을 다시 이중 종성으로 반환합니다.
  - 단어를 조합하여 "값"을 출력합니다.
  - `buffer`에서는 "ㅂ","ㅅ"을 다시 합치기 위해 `buffer.remove(2)` 후에 새로운 이중 종성 `KeyModel`을 삽입합니다..
  - `state = 1`

### case 3:
종성이 입력된 상태 ( 이중 종성 X )

입력된 텍스트를 삭제한다.

- 초성, 중성이 남는 경우
- 초성과 중성을 단어로 조합합니다. ( 종성에는 `invalidKey`를 대입합니다. )
- `state = 2`로 변경하고 조합된 단어를 출력합니다.

## `buffer`, `state` 초기화 함수 구현
enter, space 등의 키가 입력되었을 시에 `buffer`와 `state`를 초기화해야하므로 묶어서 함수로 구현하였습니다.
```swift
    func resetState() {
        buffer.removeAll()
        delBuffer.removeAll()
        state = 0
    }
```

## Shift키 초기화 함수 구현
Shift키가 `.constant` 되어있는 경우 어느 키를 누르던 다시 `.normal`로 돌아가고 `keyboardView`를 리셋해야합니다.
자주 쓰이는 로직이므로 따로 함수로 구현하였습니다.
```swift
    func resetShiftState() {
        if shiftKeyState == .constant {
            shiftKeyState = .normal
            resetKeyboardView()
        }
    }
```

## 남은 작업
- [x] 변수명 확인
- [x] controlKey 테스트

## 참조
https://wiwi-pe.tistory.com/62
https://eeyatho.tistory.com/165