### PR TITLE
단축키를 길게 누를 시에 변경하는 기능을 구현합니다

### DIFF
--- a/CustomKeyboard/CustomKeyboard.xcodeproj/project.pbxproj
+++ b/CustomKeyboard/CustomKeyboard.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		2A2C9B602A608DCC0021DD33 /* FrequentlyUsedPhrasesLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A2C9B5F2A608DCC0021DD33 /* FrequentlyUsedPhrasesLabel.swift */; };
 		2A2C9B622A61158F0021DD33 /* Value.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A2C9B612A61158F0021DD33 /* Value.swift */; };
 		2A2D4AE42A618D290089FE29 /* Hangul.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A2D4AE32A618D290089FE29 /* Hangul.swift */; };
+		2A2D4AE72A64B6E00089FE29 /* ShortCutsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A2D4AE62A64B6E00089FE29 /* ShortCutsView.swift */; };
+		2A2D4AEA2A64B7E70089FE29 /* ShortCutButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A2D4AE92A64B7E70089FE29 /* ShortCutButtons.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -99,6 +101,8 @@
 		2A2C9B5F2A608DCC0021DD33 /* FrequentlyUsedPhrasesLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrequentlyUsedPhrasesLabel.swift; sourceTree = "<group>"; };
 		2A2C9B612A61158F0021DD33 /* Value.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Value.swift; sourceTree = "<group>"; };
 		2A2D4AE32A618D290089FE29 /* Hangul.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hangul.swift; sourceTree = "<group>"; };
+		2A2D4AE62A64B6E00089FE29 /* ShortCutsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortCutsView.swift; sourceTree = "<group>"; };
+		2A2D4AE92A64B7E70089FE29 /* ShortCutButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortCutButtons.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -218,6 +222,7 @@
 		2A2C9AEE2A5C61BF0021DD33 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				2A2D4AE52A64B6CB0089FE29 /* ShortCutsView */,
 				2A2C9B572A6075B30021DD33 /* FrequentlyUsedPhrasesView */,
 				2A2C9B562A6075A60021DD33 /* KeyboardView */,
 			);
@@ -275,6 +280,23 @@
 			children = (
 				2A2C9B5B2A607A9B0021DD33 /* FrequentlyUsedPhrasesButton.swift */,
 				2A2C9B5F2A608DCC0021DD33 /* FrequentlyUsedPhrasesLabel.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		2A2D4AE52A64B6CB0089FE29 /* ShortCutsView */ = {
+			isa = PBXGroup;
+			children = (
+				2A2D4AE82A64B7D60089FE29 /* Components */,
+				2A2D4AE62A64B6E00089FE29 /* ShortCutsView.swift */,
+			);
+			path = ShortCutsView;
+			sourceTree = "<group>";
+		};
+		2A2D4AE82A64B7D60089FE29 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				2A2D4AE92A64B7E70089FE29 /* ShortCutButtons.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -475,7 +497,9 @@
 				2A2C9B5A2A6075E20021DD33 /* ToolbarView.swift in Sources */,
 				2A2C9B552A603CD60021DD33 /* PaddingView.swift in Sources */,
 				2A2D4AE42A618D290089FE29 /* Hangul.swift in Sources */,
+				2A2D4AEA2A64B7E70089FE29 /* ShortCutButtons.swift in Sources */,
 				2A2C9AE22A5C61730021DD33 /* KeyboardViewController.swift in Sources */,
+				2A2D4AE72A64B6E00089FE29 /* ShortCutsView.swift in Sources */,
 				2A2C9B602A608DCC0021DD33 /* FrequentlyUsedPhrasesLabel.swift in Sources */,
 				2A2C9AED2A5C618A0021DD33 /* KeyModel.swift in Sources */,
 				2A2C9B5E2A607E2A0021DD33 /* FrequentlyUsedPhrasesView.swift in Sources */,

--- a/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
+++ b/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
@@ -24,33 +24,26 @@ class KeyboardViewController: UIInputViewController {
     
     override func updateViewConstraints() {
         super.updateViewConstraints()
-        
-        // Add custom view sizing constraints here
     }
     
     override func viewDidLoad() {
         
         super.viewDidLoad()
         keyboardView = KeyboardView(.normal, !self.needsInputModeSwitchKey, shortCutTitle)
+        keyboardView.delegate = self
+        
         setUpToolBarLayout()
         setUpKeyboardViewLayout()
-        
-        keyboardView.delegate = self
-        // Perform custom UI setup here
     }
     
     override func viewWillLayoutSubviews() {
-        //self.nextKeyboardButton.isHidden = !self.needsInputModeSwitchKey
         super.viewWillLayoutSubviews()
     }
     
     override func textWillChange(_ textInput: UITextInput?) {
-        // The app is about to change the document's contents. Perform any preparation here.
     }
     
     override func textDidChange(_ textInput: UITextInput?) {
-        // The app has just changed the document's contents, the document context has been updated.
-        
         var textColor: UIColor
         let proxy = self.textDocumentProxy
         if proxy.keyboardAppearance == UIKeyboardAppearance.dark {
@@ -119,7 +112,7 @@ extension KeyboardViewController: KeyboardViewDelegate {
         shortCutsView.translatesAutoresizingMaskIntoConstraints = false
         shortCutsView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Size.keyWidth).isActive = true
         shortCutsView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -Size.keyWidth * 1.5).isActive = true
-        shortCutsView.widthAnchor.constraint(equalToConstant: Size.keyWidth * 6).isActive = true
+        shortCutsView.widthAnchor.constraint(equalToConstant: Size.keyWidth * 3).isActive = true
     }
 }
 
@@ -149,8 +142,6 @@ extension KeyboardViewController: ShortCutsViewDelegate {
         shortCutsView?.removeFromSuperview()
         shortCutsView = nil
     }
-    
-    
 }
 
 private extension KeyboardViewController {
@@ -164,8 +155,6 @@ private extension KeyboardViewController {
     }
     
     func handleKeyInput(_ key: KeyModel) {
-        
-        
         if key.uniValue > 100 {
             textDocumentProxy.insertText(key.keyword)
             return

--- a/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
+++ b/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
@@ -16,6 +16,7 @@ class KeyboardViewController: UIInputViewController {
     
     private var keyboardView: KeyboardView!
     private var frequentlyUsedPhrasesView: FrequentlyUsedPhrasesView!
+    private var shortCutsView: ShortCutsView!
     private let toolbar = ToolbarView()
     
     var shiftKeyState: ShiftKeyState = .normal
@@ -108,6 +109,21 @@ extension KeyboardViewController: KeyboardViewDelegate {
         keyboardView = KeyboardView(shiftKeyState, !self.needsInputModeSwitchKey)
         keyboardView.delegate = self
         setUpKeyboardViewLayout()
+    }
+    
+    func showShortCutsView() {
+        print("HI")
+        
+        shortCutsView = ShortCutsView()
+        view.addSubview(shortCutsView)
+        shortCutsView.translatesAutoresizingMaskIntoConstraints = false
+        shortCutsView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Size.keyWidth).isActive = true
+        shortCutsView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -Size.keyWidth * 1.5).isActive = true
+    }
+    
+    func hideShortCutsView() {
+        shortCutsView?.removeFromSuperview()
+        shortCutsView = nil
     }
 }
 

--- a/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
+++ b/CustomKeyboard/KoreanKeyboard/Controller/KeyboardViewController.swift
@@ -19,7 +19,8 @@ class KeyboardViewController: UIInputViewController {
     private var shortCutsView: ShortCutsView!
     private let toolbar = ToolbarView()
     
-    var shiftKeyState: ShiftKeyState = .normal
+    private var shiftKeyState: ShiftKeyState = .normal
+    private var shortCutTitle: String = "단축키"
     
     override func updateViewConstraints() {
         super.updateViewConstraints()
@@ -30,7 +31,7 @@ class KeyboardViewController: UIInputViewController {
     override func viewDidLoad() {
         
         super.viewDidLoad()
-        keyboardView = KeyboardView(.normal, !self.needsInputModeSwitchKey)
+        keyboardView = KeyboardView(.normal, !self.needsInputModeSwitchKey, shortCutTitle)
         setUpToolBarLayout()
         setUpKeyboardViewLayout()
         
@@ -87,7 +88,7 @@ extension KeyboardViewController: KeyboardViewDelegate {
             handleKeyDelete()
             resetShiftState()
         case 103:
-            textDocumentProxy.insertText(key.keyword)
+            textDocumentProxy.insertText(shortCutTitle)
             resetState()
             resetShiftState()
         case 104:
@@ -106,25 +107,50 @@ extension KeyboardViewController: KeyboardViewDelegate {
     
     func resetKeyboardView() {
         keyboardView.removeFromSuperview()
-        keyboardView = KeyboardView(shiftKeyState, !self.needsInputModeSwitchKey)
+        keyboardView = KeyboardView(shiftKeyState, !self.needsInputModeSwitchKey, shortCutTitle)
         keyboardView.delegate = self
         setUpKeyboardViewLayout()
     }
     
     func showShortCutsView() {
-        print("HI")
-        
         shortCutsView = ShortCutsView()
         view.addSubview(shortCutsView)
+        shortCutsView.delegate = self
         shortCutsView.translatesAutoresizingMaskIntoConstraints = false
         shortCutsView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Size.keyWidth).isActive = true
         shortCutsView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -Size.keyWidth * 1.5).isActive = true
+        shortCutsView.widthAnchor.constraint(equalToConstant: Size.keyWidth * 6).isActive = true
     }
-    
-    func hideShortCutsView() {
+}
+
+extension KeyboardViewController: ToolbarViewDelegate {
+    func setFrequentlyUsedPhrasesView(_ isSelected: Bool) {
+        if isSelected {
+            setUpFrequentlyUsedPhrasesViewLayout()
+            frequentlyUsedPhrasesView.delegate = self
+        } else {
+            frequentlyUsedPhrasesView.removeFromSuperview()
+        }
+    }
+}
+
+extension KeyboardViewController: FrequentlyUsedPhrasesViewDelegate {
+    func setFrequentlyUsedPhrases(_ text: String) {
+        let proxy = textDocumentProxy as UITextDocumentProxy
+        proxy.insertText(text)
+    }
+}
+
+extension KeyboardViewController: ShortCutsViewDelegate {
+    func setShortCutTitle(with title: String) {
+        shortCutTitle = title
+        resetKeyboardView()
+        
         shortCutsView?.removeFromSuperview()
         shortCutsView = nil
     }
+    
+    
 }
 
 private extension KeyboardViewController {
@@ -381,25 +407,6 @@ extension KeyboardViewController {
         default:
             break
         }
-    }
-}
-
-
-extension KeyboardViewController: ToolbarViewDelegate {
-    func setFrequentlyUsedPhrasesView(_ isSelected: Bool) {
-        if isSelected {
-            setUpFrequentlyUsedPhrasesViewLayout()
-            frequentlyUsedPhrasesView.delegate = self
-        } else {
-            frequentlyUsedPhrasesView.removeFromSuperview()
-        }
-    }
-}
-
-extension KeyboardViewController: FrequentlyUsedPhrasesViewDelegate {
-    func setFrequentlyUsedPhrases(_ text: String) {
-        let proxy = textDocumentProxy as UITextDocumentProxy
-        proxy.insertText(text)
     }
 }
 

--- a/CustomKeyboard/KoreanKeyboard/Literal/Size.swift
+++ b/CustomKeyboard/KoreanKeyboard/Literal/Size.swift
@@ -14,6 +14,15 @@ enum Size {
     static let keyItemSpacing: CGFloat = 6
     static let keyRowSpacing: CGFloat = 10
     
+    static let toolbarHeight: CGFloat = 44
+    static let toolbarWidth = width
+    static let toolbarButtonSpacing: CGFloat = 5
+    static let toolbarButtonLabelSize: CGFloat = 17
+    
+    static let frequentlyUsedPhrasesLabelSize: CGFloat = 20
+    static let frequentlyUsedPhrasesRowSpacing: CGFloat = 5
+    static let frequentlyUsedPhrasesLeadingSpacing: CGFloat = 5
+    
     static func firstKeyLeadingSpacing(_ keyItemCount: Int) -> CGFloat {
         return (CGFloat(((keys.first?.count ?? 10) - keyItemCount)) * (Size.keyWidth + Size.keyItemSpacing)) / 2 - keyItemSpacing
     }
@@ -29,14 +38,4 @@ enum Size {
     static func keyEdgeInsetsForConfigure() -> NSDirectionalEdgeInsets {
         return NSDirectionalEdgeInsets(top: 10, leading: 9, bottom: 10, trailing: 9)
     }
-    
-    static let toolbarHeight: CGFloat = 44
-    static let toolbarWidth = width
-    static let toolbarButtonSpacing: CGFloat = 5
-    
-    static let toolbarButtonLabelSize: CGFloat = 17
-    
-    static let frequentlyUsedPhrasesLabelSize: CGFloat = 20
-    static let frequentlyUsedPhrasesRowSpacing: CGFloat = 5
-    static let frequentlyUsedPhrasesLeadingSpacing: CGFloat = 5
 }

--- a/CustomKeyboard/KoreanKeyboard/Literal/Value.swift
+++ b/CustomKeyboard/KoreanKeyboard/Literal/Value.swift
@@ -9,4 +9,5 @@ import Foundation
 
 enum Value {
     static let frequentlyUsedPhrasesListCount: Int = frequentlyUsedPhrasesList.count
+    static let shortCutListCount: Int = shortCutList.count
 }

--- a/CustomKeyboard/KoreanKeyboard/Model/KeyModel.swift
+++ b/CustomKeyboard/KoreanKeyboard/Model/KeyModel.swift
@@ -47,3 +47,5 @@ let keys: [[KeyModel]] = [
     ]
 
 let frequentlyUsedPhrasesList: [String] = ["안녕하세요", "감사합니다", "환영해요"]
+
+let shortCutList: [String] = ["❤️", "안녕하세요", "ㅋㅋㅋ"]

--- a/CustomKeyboard/KoreanKeyboard/View/FrequentlyUsedPhrasesView/Components/FrequentlyUsedPhrasesButton.swift
+++ b/CustomKeyboard/KoreanKeyboard/View/FrequentlyUsedPhrasesView/Components/FrequentlyUsedPhrasesButton.swift
@@ -17,6 +17,7 @@ final class FrequentlyUsedPhrasesButton: UIButton {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
     private func configure() {
         if #available(iOS 15.0, *) {
             var buttonConfig = UIButton.Configuration.filled()

--- a/CustomKeyboard/KoreanKeyboard/View/FrequentlyUsedPhrasesView/Components/FrequentlyUsedPhrasesLabel.swift
+++ b/CustomKeyboard/KoreanKeyboard/View/FrequentlyUsedPhrasesView/Components/FrequentlyUsedPhrasesLabel.swift
@@ -8,7 +8,9 @@
 import UIKit
 
 final class FrequentlyUsedPhrasesLabel: UIButton {
+    
     var text: String
+    
     init(_ text: String) {
         self.text = text
         super.init(frame: .zero)

--- a/CustomKeyboard/KoreanKeyboard/View/FrequentlyUsedPhrasesView/FrequentlyUsedPhrasesView.swift
+++ b/CustomKeyboard/KoreanKeyboard/View/FrequentlyUsedPhrasesView/FrequentlyUsedPhrasesView.swift
@@ -14,6 +14,7 @@ protocol FrequentlyUsedPhrasesViewDelegate: AnyObject {
 final class FrequentlyUsedPhrasesView: UIView {
     
     weak var delegate: FrequentlyUsedPhrasesViewDelegate?
+    
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.text = "자주 쓰는 말"

--- a/CustomKeyboard/KoreanKeyboard/View/KeyboardView/Components/KeyButton.swift
+++ b/CustomKeyboard/KoreanKeyboard/View/KeyboardView/Components/KeyButton.swift
@@ -20,8 +20,10 @@ final class KeyButton: UIButton {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
     private func configure() {
         if #available(iOS 15.0, *) {
+            self.titleLabel?.adjustsFontSizeToFitWidth = true
             var buttonConfig = UIButton.Configuration.filled()
             var buttonTitleAttribute = AttributedString()
             buttonTitleAttribute.font = .systemFont(ofSize: 17)

--- a/CustomKeyboard/KoreanKeyboard/View/KeyboardView/KeyboardView.swift
+++ b/CustomKeyboard/KoreanKeyboard/View/KeyboardView/KeyboardView.swift
@@ -10,7 +10,6 @@ import UIKit
 protocol KeyboardViewDelegate: AnyObject {
     func setKeyAction(key: KeyModel)
     func showShortCutsView()
-    func hideShortCutsView()
 }
 
 class KeyboardView: UIView {
@@ -29,11 +28,12 @@ class KeyboardView: UIView {
     weak var delegate: KeyboardViewDelegate?
     private var shiftState: ShiftKeyState
     private var switchKeyState: Bool
-
+    private var shortCutTitle: String
     
-    init(_ shiftState: ShiftKeyState, _ switchKeyState: Bool) {
+    init(_ shiftState: ShiftKeyState, _ switchKeyState: Bool, _ shortCutTitle: String) {
         self.shiftState = shiftState
         self.switchKeyState = switchKeyState
+        self.shortCutTitle = shortCutTitle
         super.init(frame: .zero)
         setUpKeyboardStackView()
         setUpKeyboardStackViewLayout()
@@ -70,6 +70,7 @@ class KeyboardView: UIView {
                 let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(shortCutButtonPressed))
                 longPressGesture.minimumPressDuration = 0.5
                 keyButton.addGestureRecognizer(longPressGesture)
+                keyButton.setTitle(shortCutTitle, for: .normal)
             default: break
             }
             if key.keyword == "ㅁ" {
@@ -98,7 +99,6 @@ class KeyboardView: UIView {
     
     @objc func shortCutButtonPressed(_ gesture: UILongPressGestureRecognizer) {
         guard gesture.state == .began else {
-            delegate?.hideShortCutsView()
             return
         }
         delegate?.showShortCutsView()

--- a/CustomKeyboard/KoreanKeyboard/View/KeyboardView/KeyboardView.swift
+++ b/CustomKeyboard/KoreanKeyboard/View/KeyboardView/KeyboardView.swift
@@ -102,10 +102,7 @@ class KeyboardView: UIView {
             return
         }
         delegate?.showShortCutsView()
-        
      }
-    
-
 }
 
 private extension KeyboardView {

--- a/CustomKeyboard/KoreanKeyboard/View/KeyboardView/KeyboardView.swift
+++ b/CustomKeyboard/KoreanKeyboard/View/KeyboardView/KeyboardView.swift
@@ -9,6 +9,8 @@ import UIKit
 
 protocol KeyboardViewDelegate: AnyObject {
     func setKeyAction(key: KeyModel)
+    func showShortCutsView()
+    func hideShortCutsView()
 }
 
 class KeyboardView: UIView {
@@ -25,8 +27,9 @@ class KeyboardView: UIView {
     }()
     
     weak var delegate: KeyboardViewDelegate?
-    var shiftState: ShiftKeyState
-    var switchKeyState: Bool
+    private var shiftState: ShiftKeyState
+    private var switchKeyState: Bool
+
     
     init(_ shiftState: ShiftKeyState, _ switchKeyState: Bool) {
         self.shiftState = shiftState
@@ -63,6 +66,10 @@ class KeyboardView: UIView {
                 keyButton.configuration = shiftButtonConfig
             case 100:
                 keyButton.isHidden = switchKeyState
+            case 103:
+                let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(shortCutButtonPressed))
+                longPressGesture.minimumPressDuration = 0.5
+                keyButton.addGestureRecognizer(longPressGesture)
             default: break
             }
             if key.keyword == "ㅁ" {
@@ -88,6 +95,17 @@ class KeyboardView: UIView {
     @objc func keyButtonPressed(_ sender: KeyButton) {
         delegate?.setKeyAction(key: sender.keyValue)
     }
+    
+    @objc func shortCutButtonPressed(_ gesture: UILongPressGestureRecognizer) {
+        guard gesture.state == .began else {
+            delegate?.hideShortCutsView()
+            return
+        }
+        delegate?.showShortCutsView()
+        
+     }
+    
+
 }
 
 private extension KeyboardView {

--- a/CustomKeyboard/KoreanKeyboard/View/ShortCutsView/Components/ShortCutButtons.swift
+++ b/CustomKeyboard/KoreanKeyboard/View/ShortCutsView/Components/ShortCutButtons.swift
@@ -1,0 +1,40 @@
+//
+//  ShortCutButtons.swift
+//  KoreanKeyboard
+//
+//  Created by 한택환 on 2023/07/17.
+//
+
+import UIKit
+
+final class ShortCutButtons: UIButton {
+    
+    init(_ title: String) {
+        super.init(frame: .zero)
+        self.setTitle(title, for: .normal)
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    private func configure() {
+        if #available(iOS 15.0, *) {
+            var buttonConfig = UIButton.Configuration.filled()
+            var buttonTitleAttribute = AttributedString()
+            buttonTitleAttribute.font = .systemFont(ofSize: 17)
+            buttonConfig.attributedTitle = buttonTitleAttribute
+            buttonConfig.titleAlignment = .center
+            buttonConfig.contentInsets = Size.keyEdgeInsetsForConfigure()
+            buttonConfig.baseForegroundColor = .white
+            buttonConfig.baseBackgroundColor = .gray
+            self.configuration = buttonConfig
+        } else {
+            self.contentEdgeInsets = Size.keyEdgeInsets()
+            self.titleLabel?.font = UIFont.systemFont(ofSize: 17)
+            self.titleLabel?.textAlignment = .center
+            self.backgroundColor = .systemGray
+            self.setTitleColor(.white, for: .normal)
+        }
+    }
+}

--- a/CustomKeyboard/KoreanKeyboard/View/ShortCutsView/Components/ShortCutButtons.swift
+++ b/CustomKeyboard/KoreanKeyboard/View/ShortCutsView/Components/ShortCutButtons.swift
@@ -19,22 +19,10 @@ final class ShortCutButtons: UIButton {
         fatalError("init(coder:) has not been implemented")
     }
     private func configure() {
-        if #available(iOS 15.0, *) {
-            var buttonConfig = UIButton.Configuration.filled()
-            var buttonTitleAttribute = AttributedString()
-            buttonTitleAttribute.font = .systemFont(ofSize: 17)
-            buttonConfig.attributedTitle = buttonTitleAttribute
-            buttonConfig.titleAlignment = .center
-            buttonConfig.contentInsets = Size.keyEdgeInsetsForConfigure()
-            buttonConfig.baseForegroundColor = .white
-            buttonConfig.baseBackgroundColor = .gray
-            self.configuration = buttonConfig
-        } else {
-            self.contentEdgeInsets = Size.keyEdgeInsets()
-            self.titleLabel?.font = UIFont.systemFont(ofSize: 17)
-            self.titleLabel?.textAlignment = .center
-            self.backgroundColor = .systemGray
-            self.setTitleColor(.white, for: .normal)
-        }
+        self.titleLabel?.adjustsFontSizeToFitWidth = true
+        self.titleLabel?.font = UIFont.systemFont(ofSize: 17)
+        self.titleLabel?.textAlignment = .center
+        self.backgroundColor = .systemGray
+        self.setTitleColor(.white, for: .normal)
     }
 }

--- a/CustomKeyboard/KoreanKeyboard/View/ShortCutsView/ShortCutsView.swift
+++ b/CustomKeyboard/KoreanKeyboard/View/ShortCutsView/ShortCutsView.swift
@@ -7,7 +7,12 @@
 
 import UIKit
 
+protocol ShortCutsViewDelegate: AnyObject {
+    func setShortCutTitle(with title: String)
+}
+
 final class ShortCutsView: UIView {
+    weak var delegate: ShortCutsViewDelegate?
     
     init() {
         super.init(frame: .zero)
@@ -22,6 +27,10 @@ final class ShortCutsView: UIView {
     private func configure() {
         self.backgroundColor = .gray
     }
+    
+    @objc private func shortCutButtonPressed(_ sender: UIButton) {
+         delegate?.setShortCutTitle(with: sender.currentTitle ?? "")
+     }
 }
 
 private extension ShortCutsView {
@@ -30,6 +39,7 @@ private extension ShortCutsView {
         for idx in 0..<Value.shortCutListCount {
             let text = shortCutList[idx]
             let button = ShortCutButtons(text)
+            button.addTarget(self, action: #selector(shortCutButtonPressed), for: .touchUpInside)
             addSubview(button)
             button.translatesAutoresizingMaskIntoConstraints = false
             if let firstButton = firstButton {

--- a/CustomKeyboard/KoreanKeyboard/View/ShortCutsView/ShortCutsView.swift
+++ b/CustomKeyboard/KoreanKeyboard/View/ShortCutsView/ShortCutsView.swift
@@ -49,7 +49,8 @@ private extension ShortCutsView {
             }
             NSLayoutConstraint.activate([
                 button.topAnchor.constraint(equalTo: self.topAnchor),
-                button.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+                button.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+                button.widthAnchor.constraint(equalToConstant: Size.keyWidth)
             ])
             firstButton = button
         }

--- a/CustomKeyboard/KoreanKeyboard/View/ShortCutsView/ShortCutsView.swift
+++ b/CustomKeyboard/KoreanKeyboard/View/ShortCutsView/ShortCutsView.swift
@@ -1,0 +1,46 @@
+//
+//  ShortCutsView.swift
+//  KoreanKeyboard
+//
+//  Created by 한택환 on 2023/07/17.
+//
+
+import UIKit
+
+final class ShortCutsView: UIView {
+    
+    
+    init() {
+        super.init(frame: .zero)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func configure() {
+        self.backgroundColor = .systemGray
+    }
+}
+
+private extension ShortCutsView {
+    func setUpShortCutsButtonLayout() {
+        var firstButton: ShortCutButtons?
+        for idx in 0..<Value.shortCutListCount {
+            let text = shortCutList[idx]
+            let button = ShortCutButtons(text)
+            addSubview(button)
+            button.translatesAutoresizingMaskIntoConstraints = false
+            if let firstButton = firstButton {
+                button.leadingAnchor.constraint(equalTo: firstButton.trailingAnchor).isActive = true
+            } else {
+                button.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
+            }
+            NSLayoutConstraint.activate([
+                button.topAnchor.constraint(equalTo: self.topAnchor),
+                button.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+            ])
+            firstButton = button
+        }
+    }
+}

--- a/CustomKeyboard/KoreanKeyboard/View/ShortCutsView/ShortCutsView.swift
+++ b/CustomKeyboard/KoreanKeyboard/View/ShortCutsView/ShortCutsView.swift
@@ -9,9 +9,10 @@ import UIKit
 
 final class ShortCutsView: UIView {
     
-    
     init() {
         super.init(frame: .zero)
+        configure()
+        setUpShortCutsButtonLayout()
     }
     
     required init?(coder: NSCoder) {
@@ -19,7 +20,7 @@ final class ShortCutsView: UIView {
     }
     
     private func configure() {
-        self.backgroundColor = .systemGray
+        self.backgroundColor = .gray
     }
 }
 


### PR DESCRIPTION
# 단축키를 길게 누를 시에 변경하는 기능을 구현합니다
close #12 
구현 사항
- 단축키를 길게 누를 시에 나오는 ShortCutsView UI 구현
- Delegate패턴을 통한 ShortCutsView 띄우는 이벤트 구현
- Delegate 패턴을 활용한 ShortCutTitle을 바꾸고 keyboardView를 리셋하는 이벤트 구현

## 설계 화면
#12와 달라진 점은 없습니다.
<img width="500" src = "https://github.com/TaekH/CustomKeyboard/assets/103012087/9cebf9dd-1f48-47d9-8781-e09f80dc5e2f">

## 구현 화면

![단축키](https://github.com/TaekH/CustomKeyboard/assets/103012087/301e9895-4982-40bc-b0a6-a83db0e313bb)



## ShortCutsViewUI 구현
#8 와 비슷한 로직으로 `UIView`로 구현한 후에 `ShortCutButton`을 `UIView`에서 인스턴스를 생성하였습니다.
```swift
    func setUpShortCutsButtonLayout() {
        var firstButton: ShortCutButtons?
        for idx in 0..<Value.shortCutListCount {
            let text = shortCutList[idx]
            let button = ShortCutButtons(text)
            button.addTarget(self, action: #selector(shortCutButtonPressed), for: .touchUpInside)
            addSubview(button)
            button.translatesAutoresizingMaskIntoConstraints = false
            if let firstButton = firstButton {
                button.leadingAnchor.constraint(equalTo: firstButton.trailingAnchor).isActive = true
            } else {
                button.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
            }
            NSLayoutConstraint.activate([
                button.topAnchor.constraint(equalTo: self.topAnchor),
                button.bottomAnchor.constraint(equalTo: self.bottomAnchor)
            ])
            firstButton = button
        }
    }
```
firstButton의 역할은 이후 계속해서 붙는 버튼들의 직전 버튼으로서 오토레이아웃의 기준점 역할을 하게 됩니다.

생성 과정에서 `title`은 미리 `KeyModel`에 구현해 둔 `ShortCutList` MockData 를 활용하였습니다.

## Delegate패턴을 활용한 `ShortCutView` 띄우는 이벤트 구현
`KeyboardView()`의 `setUpRowStackView()`에서 `Key`를 만드는 과정 중 만약 `key`가 단축키라면
```swift
              let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(shortCutButtonPressed))
                longPressGesture.minimumPressDuration = 0.5
                keyButton.addGestureRecognizer(longPressGesture)
                keyButton.setTitle(shortCutTitle, for: .normal)
```
키를 0.5초 동안 길게 눌렀을 시에 `shortCutButtonPressed()` 라는 함수를 호출합니다.
이 함수는 
```swift
    @objc func shortCutButtonPressed(_ gesture: UILongPressGestureRecognizer) {
        guard gesture.state == .began else {
            return
        }
        delegate?.showShortCutsView()
        
     }
```
`showShortCutsView()` 라는 `delegate` 패턴의 함수를 호출합니다.
`KeyboardView()`는 `KeyboardViewController`가 소유하면서 `ViewController`에서 대리자 역할을 수행하고 `ShortCutsView`를 띄우게 됩니다.

## Delegate 패턴을 활용한 ShortCutTitle을 적용하는 이벤트 구현
위와 같은 방식의 delegate 패턴이지만 `ShortCutsView()`의 `ShortCutButton`의 액션을 처리합니다.
Button이 선택되었을 시에 선택된 Button의 `Title`로 `shortCutTitle` 변수를 변경하고 이를 `KeyboardView`의 변수에 전달합니다.
이 변수는 위의 단축키의 `setTitle`로 들어가 `title`을 결정하게 됩니다.

또한 ViewController의 shortCutTitle은 
```swift
        case 103:
            textDocumentProxy.insertText(shortCutTitle)
            resetState()
            resetShiftState()
```
단축키가 눌렸을 시에 화면에 입력될 텍스트의 변수로 들어갑니다.

이를 통해 단축키가 변경되면 입력되는 텍스트가 변경되게 됩니다.


## 이슈
`ShortCut`의 텍스트가 길어지더라도 키보드의 버튼 크기는 유지되도록 하고 싶었으나 iOS15 이상부터 적용되는 `Configuration` 에는 `adjustsFontSizeToFitWidth`이 적용되지 않아 단축키의 크기가 텍스트에 따라 유동적으로 변화하는 이슈가 있습니다.

`EdgeInset`과 `adjustsFontSizeToFitWidth` 중 하나를 선택해야할지 아니면 다른 방법이 있을지 더 찾아봐야할 것 같습니다.

`EdgeInset`을 사용하지 않는 `ShortCutButton`의 경우에는 `Configuration`을 빼고 `adjustsFontSizeToFitWidth`을 적용하였습니다.