### PR TITLE
KeyButton의 터치영역을 확대하였습니다

### DIFF
--- a/CustomKeyboard/KoreanKeyboard/View/KeyboardView/Components/KeyButton.swift
+++ b/CustomKeyboard/KoreanKeyboard/View/KeyboardView/Components/KeyButton.swift
@@ -21,6 +21,13 @@ final class KeyButton: UIButton {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        super.point(inside: point, with: event)
+        
+        let area = bounds.insetBy(dx: -Size.keyItemSpacing, dy: -Size.keyRowSpacing)
+        return area.contains(point)
+    }
+    
     private func configure() {
         if #available(iOS 15.0, *) {
             self.titleLabel?.adjustsFontSizeToFitWidth = true


### PR DESCRIPTION
## point 메소드를 오버라이드하여 KeyButton의 터치영역을 확대하였습니다.
close #16 

### 구현 전 설계
<img width="500" alt="image" src="https://github.com/TaekH/CustomKeyboard/assets/103012087/653a48a1-4d97-44e6-9730-5eeb684aa62d">


### 구현 화면

https://github.com/TaekH/CustomKeyboard/assets/103012087/368c5d9b-41fc-47d8-b339-b9946d70c625


### `point`메소드를 오버라이드하여 터치영역 확대

`area`라는 프로퍼티를 생성하고 현재 `UIButton`의 크기를 확대합니다.
재정의 된 `area`가 `point`보다 큰지에 대한 `Bool`값을 반환함으로써 `UIButton`의 터치 영역을 확장하게 됩니다.

### 
``` swift
override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
        super.point(inside: point, with: event)
        
        let area = bounds.insetBy(dx: -Size.keyItemSpacing, dy: -Size.keyRowSpacing)
        return area.contains(point)
    }
```

여기서 `area`는 `insetBy`라는 메소드를 통해서 `dx`, `dy`를 재정의하게 되는데,  `dx`는 x 좌표 값으로 영역을 넓히려면 음수를 좁히려면 양수를 대입합니다. `dy`는 y좌표 값으로 `dx`와 마찬가지로 대입합니다.

이렇게 확장된 `area` 변수 내에 `point`가 포함되는지를 반환하고 `true`라면 확장된 터치 영역이 활성화 됩니다.

